### PR TITLE
fix: example helper method for webhooks

### DIFF
--- a/docs/articles/webhooks.mdx
+++ b/docs/articles/webhooks.mdx
@@ -239,7 +239,7 @@ Usage example:
 
 ```yaml
   - name: TEXT_COLOUR
-    value: {{ if eq (.TestWorkflowExecution.Status | testworkflowstatustostring ) "passed" }}"00FF00"{{ else }}"FF0000"{{ end }}
+    value: {{ if eq (.TestWorkflowExecution.Result.Status | testworkflowstatustostring ) "passed" }}"00FF00"{{ else }}"FF0000"{{ end }}
 ```
 
 #### Using API Server Environment Variables in Webhooks


### PR DESCRIPTION
## Changes

- use `.TestWorkflowExecution.Result.Status` instead of unknown `.TestWorkflowExecution.Status`

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
