### PR TITLE
chore: add testkube ai http proxy configuration step

### DIFF
--- a/docs/articles/copilot-on-prem-install.md
+++ b/docs/articles/copilot-on-prem-install.md
@@ -28,3 +28,19 @@ testkube-ai-service:
   openAi:
     secretRef: <secret name>
 ```
+
+If internet access is restringed with a Http Proxy, use the `extraEnvVars` property to configure the required environment variables:
+
+```yaml
+testkube-ai-service:
+  enabled: true
+  openAi:
+    secretRef: <secret name>
+  extraEnvVars:
+    - name: HTTP_PROXY
+      value: "http://proxy.domain:8080"
+    - name: HTTPS_PROXY
+      value: "https://proxy.domain:8043"
+    - name: NO_PROXY
+      value: ""
+```


### PR DESCRIPTION
This PR includes a change in an existing article. It depends on the change done in the Testkube Copilot helm chart: https://github.com/kubeshop/testkube-ai/pull/115.

## Changes

- Add step to configure Http Proxy in the Testkube Copilot deployment.

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [X] updated the docs
- [ ] added a test
