### PR TITLE
chore: [TKC-3216] push image inventory updates directly to main

### DIFF
--- a/.github/workflows/update-image-inventory.yaml
+++ b/.github/workflows/update-image-inventory.yaml
@@ -39,6 +39,5 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "docs: update image inventory"
-          branch: update-image-inventory
-          create_branch: true
+          branch: main
           push_options: '--force'

--- a/.github/workflows/update-image-inventory.yaml
+++ b/.github/workflows/update-image-inventory.yaml
@@ -1,6 +1,8 @@
 name: Update image inventory
 
-on: workflow_dispatch
+on:
+  schedule:
+    - cron: "0 0 * * *"
 
 jobs:
   lint-images:


### PR DESCRIPTION
This PR contains the changes needed to schedule image inventory updates applying changes directly in main.

## Changes

- Schedule image inventory updates and aim directly to main branch.

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
