### PR TITLE
chore: add note explaining where runner will be installed when execute cli command

### DIFF
--- a/docs/articles/multi-agent-cli.md
+++ b/docs/articles/multi-agent-cli.md
@@ -86,6 +86,10 @@ you want to associate with the created Runner.
 $ testkube install runner staging-runner --create -l env=staging
 ```
 
+:::note
+This command installs the runner into the Kubernetes cluster configured as the current context, before install check if it's the expected by running the command: `kubectl config current-context`. Use parameter `--namespace <namespace-name>` to place runner in a different namespace, by default it uses the name of the runner.
+:::
+
 :::tip
 You can also install Runner Agents from a Helm Chart - [Read More](/articles/multi-agent-runner-helm-chart)
 :::


### PR DESCRIPTION
This PR add note to explain where runner is installed when running the command install runner.

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
