### PR TITLE
fix: remove unsupported matchExpression

### DIFF
--- a/docs/articles/test-triggers.md
+++ b/docs/articles/test-triggers.md
@@ -122,11 +122,9 @@ testSelector:
   nameRegex: TestWorkflow name regex (for example, "test.*")
   labelSelector:
     matchLabels: map of key-value pairs
-    matchExpressions:
-      - key: label name
-        operator: [In | NotIn | Exists | DoesNotExist
-        values: list of values
 ```
+
+Note: labelSelector.matchExpressions will be supported in a future release.
 
 ## Resource Conditions
 


### PR DESCRIPTION
We don't support matchExpressions, it fails with:

>return nil, errors.New("error creating selector from test resource label selector: MatchExpressions not supported")

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
