### PR TITLE
fix: update multi-agent redirect to point to agents-overview

### DIFF
--- a/redirects.js
+++ b/redirects.js
@@ -609,7 +609,7 @@ const redirects = [
   },
   {
     from: "/articles/install/multi-agent",
-    to: "/articles/environment-management",
+    to: "/articles/agents-overview",
   },
   {
     from: "/testkube-pro/articles/agent-management",


### PR DESCRIPTION
This PR...

## Changes

-

## Fixes

- Fixes incorrect redirect for `/articles/install/multi-agent` to point to `/articles/agents-overview` instead of /articles/environment-management`

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
