### PR TITLE
TKC-5510 - Update slack link to invite instead of signup domain URL

### DIFF
--- a/docs/articles/examples/overview.mdx
+++ b/docs/articles/examples/overview.mdx
@@ -1,9 +1,9 @@
 # Testkube Examples and Guides
 
-This section gives examples on how to create Workflows for the most common testing tools - 
+This section gives examples on how to create Workflows for the most common testing tools -
 
 :::tip
-If you're missing an example for your favorite testing tool please let us know on our [Slack Channel](https://bit.ly/testkube-slack)
+If you're missing an example for your favorite testing tool please let us know on our [Slack Channel](https://join.slack.com/t/testkubeworkspace/shared_invite/zt-3kfpny0gx-apPMq9_Swu4KG3uwz6Bk2g)
 or open an issue on our [GitHub Repository](https://github.com/kubeshop/testkube-docs/issues).
 :::
 

--- a/docs/articles/getting-started-with-open-source.md
+++ b/docs/articles/getting-started-with-open-source.md
@@ -162,5 +162,5 @@ Congrats on getting up and running with Testkube, now you can
 - Head over to the [Examples & Guides](/articles/examples/overview) for sample Test Workflows with popular testing tools.
 - Check out the [Getting Started with Testkube Open Source](https://testkube.io/blog/getting-started-with-testkube-open-source) blogpost to further see how you can use the Standalone Agent with GitHub Actions
 - Go through the [CLI Reference](/cli/testkube) to see available CLI commands.
-- Head over to the [Testkube Slack](https://bit.ly/testkube-slack) to ask questions and get answers.
+- Head over to the [Testkube Slack](https://join.slack.com/t/testkubeworkspace/shared_invite/zt-3kfpny0gx-apPMq9_Swu4KG3uwz6Bk2g) to ask questions and get answers.
 

--- a/docs/articles/mcp-overview.md
+++ b/docs/articles/mcp-overview.md
@@ -162,5 +162,5 @@ Analyze the logs of execution "api-tests-123" and suggest fixes
 ## Need Help?
 
 :::info
-Don't hesitate to reach out to us on [Slack](https://bit.ly/testkube-slack) if you run into any issues!
+Don't hesitate to reach out to us on [Slack](https://join.slack.com/t/testkubeworkspace/shared_invite/zt-3kfpny0gx-apPMq9_Swu4KG3uwz6Bk2g) if you run into any issues!
 :::

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -128,7 +128,7 @@ const config = {
           {
             label: "Slack",
             position: "right",
-            href: "https://bit.ly/testkube-slack",
+            href: "https://join.slack.com/t/testkubeworkspace/shared_invite/zt-3kfpny0gx-apPMq9_Swu4KG3uwz6Bk2g",
           },
           {
             label: "Marketplace",
@@ -172,7 +172,7 @@ const config = {
           },
           {
             label: "Slack",
-            href: "https://bit.ly/testkube-slack",
+            href: "https://join.slack.com/t/testkubeworkspace/shared_invite/zt-3kfpny0gx-apPMq9_Swu4KG3uwz6Bk2g",
           },
           {
             label: "Twitter",


### PR DESCRIPTION
This PR...

## Changes

- Updates Slack URL to use invite link to improve onboarding experience.

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
