### PR TITLE
docs: [TKC-5485] document TestWorkflow security context behavior

### DIFF
--- a/docs/articles/deploying-on-openshift.md
+++ b/docs/articles/deploying-on-openshift.md
@@ -2,6 +2,48 @@
 
 When deploying Testkube in an OpenShift cluster, you can expose its public endpoints using OpenShift Routes while securing them with custom certificates.
 
+## TestWorkflow security context on OpenShift
+
+OpenShift often expects the platform to assign the effective runtime UID and GID through Security Context Constraints.
+For TestWorkflows, this matters most when you use `parallel`, because each worker is created as a separate Kubernetes Job.
+
+If you want Testkube to leave pod `securityContext.fsGroup` unset so OpenShift can assign it, use:
+
+```yaml
+apiVersion: testworkflows.testkube.io/v1
+kind: TestWorkflow
+metadata:
+  name: openshift-parallel-example
+spec:
+  pod:
+    disableFsGroupDefaulting: true
+  steps:
+  - name: Run in parallel
+    parallel:
+      count: 2
+      shell: |
+        id
+```
+
+If you need different behavior only for worker pods, set it on the parallel step instead:
+
+```yaml
+spec:
+  steps:
+  - name: Run in parallel
+    parallel:
+      count: 2
+      pod:
+        disableFsGroupDefaulting: true
+      shell: id
+```
+
+If you explicitly set `pod.securityContext.fsGroup`, that explicit value still takes precedence.
+
+For `runAsUser` and `runAsNonRoot`, Testkube does not apply similar defaulting. Set them explicitly in the workflow if you need fixed values, or leave them unset if you want OpenShift to control them.
+
+See [Test Workflows - Job and Pod Configuration](/articles/test-workflows-job-and-pod#fsgroup-and-runasgroup-defaulting) for the full defaulting behavior.
+
 ## Prerequisites
 - OpenShift cluster (version 4.5 and later)
 - OpenShift CLI installed with the same version of the cluster (or later)

--- a/docs/articles/deploying-on-openshift.md
+++ b/docs/articles/deploying-on-openshift.md
@@ -40,8 +40,6 @@ spec:
 
 If you explicitly set `pod.securityContext.fsGroup`, that explicit value still takes precedence.
 
-For `runAsUser` and `runAsNonRoot`, Testkube does not apply similar defaulting. Set them explicitly in the workflow if you need fixed values, or leave them unset if you want OpenShift to control them.
-
 See [Test Workflows - Job and Pod Configuration](/articles/test-workflows-job-and-pod#fsgroup-and-runasgroup-defaulting) for the full defaulting behavior.
 
 ## Prerequisites

--- a/docs/articles/test-workflows-job-and-pod.md
+++ b/docs/articles/test-workflows-job-and-pod.md
@@ -83,6 +83,123 @@ pod:
     runAsUser: 100690000
 ```
 
+### fsGroup and runAsGroup defaulting
+
+Testkube applies a small amount of security-context defaulting for TestWorkflow execution pods.
+This matters most for [parallel workers](./test-workflows-parallel.mdx), because they run as separate Jobs and Pods.
+
+The effective logic is:
+
+1. If you explicitly set `pod.securityContext.fsGroup`, Testkube uses that value as-is.
+2. If `fsGroup` is not set, Testkube may inspect the image metadata for the main non-Testkube container.
+   If the image has a numeric group in its `USER` declaration, for example `USER 1001:1001`,
+   Testkube can reuse that group.
+3. If Testkube still cannot resolve a group, it defaults pod `fsGroup` to `1001`.
+4. When an effective pod `fsGroup` exists, missing container `securityContext.runAsGroup` values may be backfilled from it.
+
+This means that an image with a root group, or an image that resolves to group `0`, can produce:
+
+```yaml
+pod:
+  securityContext:
+    fsGroup: 0
+```
+
+For clusters such as OpenShift, that may be undesirable because the platform is expected to inject the runtime group automatically.
+
+### Disabling fsGroup defaulting
+
+Testkube supports disabling automatic pod `fsGroup` injection with `disableFsGroupDefaulting`.
+
+Use it when you want Testkube to leave pod `securityContext.fsGroup` unset unless you explicitly provide one.
+
+```yaml
+spec:
+  pod:
+    disableFsGroupDefaulting: true
+```
+
+With this setting:
+
+* explicit `pod.securityContext.fsGroup` still wins
+* Testkube stops inferring pod `fsGroup` from image metadata
+* Testkube stops injecting the fallback default `fsGroup: 1001`
+
+This is especially useful on OpenShift when the Security Context Constraints should assign the group automatically.
+
+### What about runAsUser and runAsNonRoot?
+
+`runAsUser` and `runAsNonRoot` follow different rules than `fsGroup`.
+
+Testkube does **not** currently infer or default:
+
+* pod `securityContext.runAsUser`
+* pod `securityContext.runAsNonRoot`
+* container `securityContext.runAsUser`
+* container `securityContext.runAsNonRoot`
+
+For these fields, Testkube only passes through what you define explicitly in the workflow.
+
+```yaml
+spec:
+  pod:
+    securityContext:
+      runAsUser: 1000650001
+      runAsNonRoot: true
+```
+
+If you do not set those fields:
+
+* Testkube does not synthesize values for them
+* the container image's own default `USER` may still apply at runtime
+* your cluster policy, such as OpenShift SCCs or other admission controls, may also inject or enforce them
+
+Testkube does inspect image metadata, but for this security-context path it only uses the numeric **group** portion of the image `USER` field when calculating `runAsGroup` / `fsGroup`.
+It does **not** take the image user ID and copy it into `runAsUser`.
+
+In other words:
+
+* image `USER 1001:1001` can influence `runAsGroup` / `fsGroup`
+* it does not cause Testkube to write `runAsUser: 1001`
+* static files or other workflow content are not used for security-context inference
+
+### Examples
+
+#### Set a fixed fsGroup explicitly
+
+```yaml
+spec:
+  pod:
+    securityContext:
+      fsGroup: 1000650001
+```
+
+#### Leave fsGroup unset for the whole workflow
+
+This affects the main execution pod and is also inherited by parallel worker pods unless a parallel step overrides it.
+
+```yaml
+spec:
+  pod:
+    disableFsGroupDefaulting: true
+```
+
+#### Disable fsGroup defaulting only for a parallel step
+
+```yaml
+spec:
+  steps:
+  - name: Run shards
+    parallel:
+      count: 4
+      pod:
+        disableFsGroupDefaulting: true
+      shell: |
+        echo "worker {{ index + 1 }}/{{ count }}"
+```
+
+If you define both `spec.pod` and `steps[].parallel.pod`, the parallel step pod settings override the inherited root pod settings for those workers.
+
 ### Service Account
 
 By default, Testkube creates and uses a service account that will allow you to use all Testkube features.
@@ -182,4 +299,3 @@ container:
   - name: some-name
     mountPath: /mnt/some/name
 ```
-

--- a/docs/articles/test-workflows-parallel.mdx
+++ b/docs/articles/test-workflows-parallel.mdx
@@ -41,6 +41,37 @@ It takes an expression condition, so you can dynamically choose whether it shoul
 
 The parallel steps are started as a separate jobs/pods, so you can configure `pod` and `job` similarly to general Test Workflow.
 
+Root workflow `spec.pod` settings are inherited by parallel worker pods.
+If you need worker-specific behavior, define `steps[].parallel.pod`, which overrides the inherited pod settings for those workers.
+
+This is particularly useful for security context handling, for example:
+
+```yaml
+spec:
+  pod:
+    disableFsGroupDefaulting: true
+  steps:
+  - name: Run tests
+    parallel:
+      count: 4
+      shell: npm test
+```
+
+Or, if you only want to change the worker pods:
+
+```yaml
+spec:
+  steps:
+  - name: Run tests
+    parallel:
+      count: 4
+      pod:
+        disableFsGroupDefaulting: true
+      shell: npm test
+```
+
+See [Job and Pod Configuration](./test-workflows-job-and-pod.md#fsgroup-and-runasgroup-defaulting) for the full security-context defaulting rules.
+
 ### Lifecycle
 
 Similarly to regular steps, you can configure things like `timeout` (`timeout: 30m`), `optional: true`, or `negative: true` for expecting failure.


### PR DESCRIPTION
## Summary
- document how Testkube handles TestWorkflow pod and container security context values
- document the new  option for workflows and parallel workers
- add OpenShift-specific guidance for leaving  unset

## Details
This adds missing documentation for the current TestWorkflow security-context behavior, including:
- when  is explicit
- when Testkube derives group information from image metadata
- when Testkube falls back to 
- what is and is not inferred for , , and 
- how root  settings are inherited by parallel worker pods

Linear: https://linear.app/kubeshop/issue/TKC-5485/allow-disabling-testworkflow-fsgroup-defaulting-for-openshift