### PR TITLE
docs(changelog): bump release entry from 2.9.0 to 2.9.1

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -8,9 +8,9 @@ This is the changelog for the Testkube Control Plane, latest releases are on top
 - **Doc updates** focus on major changes to the documentation
   :::
 
-## Monthly Release v2.9.0 (2026-04-23)
+## Monthly Release v2.9.1 (2026-04-23)
 
-Control Plane and Agent continue with unified versioning at **v2.9.0**.
+Control Plane and Agent continue with unified versioning at **v2.9.1**.
 
 ### What's new!
 


### PR DESCRIPTION
## Summary
- change changelog monthly release heading from `v2.9.0` to `v2.9.1`
- update unified version text from `v2.9.0` to `v2.9.1`

## Reason
- `2.9.0` failed to publish, so changelog should reference `2.9.1` as the release version