### PR TITLE
docs: [TKC-5298] add runner global template changelog note

### DIFF
--- a/docs/articles/multi-agent-runner-helm-chart.md
+++ b/docs/articles/multi-agent-runner-helm-chart.md
@@ -176,6 +176,7 @@ It's useful, for example, to set up OpenShift's security context that will be se
 ```yaml
 globalTemplate:
   enabled: true
+  inline: true
   spec:
    pod:
      securityContext:

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -200,7 +200,7 @@ Control Plane is available in Helm chart `v2.331.2` and the Agent is available i
 
 - Installation OSS Agent: remove operator and param as it's already deprecated, replacing by Testkube CRDs only.
 - `testkube-agent` is deprecated in the `testkube-enterprise` chart.
-- Testkube Agent Global Template: manage if it's inline and the name of the Global Template from Testkube Agent helm chart properties.
+- Testkube Agent Global Template: manage inline and named Global Templates from Testkube Agent Helm chart properties. When upgrading the `testkube-runner` Helm chart from `2.7.x`, inline global templates must now set `globalTemplate.inline: true`. Without `inline: true`, the chart treats the global template as a named external template and requires `globalTemplate.name`.
 - Testkube Agent Name: allow override agent name from Testkube Agent helm chart property `runner.name`.
 - Follow long Test Workflow executions: improve the behavior when the underlying execution is healthy but the live log stream is interrupted by the network path between the CLI runner and the Control Plane.
 


### PR DESCRIPTION
## Summary
- Add a v2.9 changelog upgrade note for `testkube-runner` global templates when upgrading from 2.7.x to 2.9.x
- Document that inline global template specs now need `globalTemplate.inline: true`

## Validation
- `git diff --check origin/main -- docs/changelog.mdx`