### PR TITLE
fix(docs): correct Claude Desktop MCP configuration examples

### DIFF
--- a/docs/articles/mcp-configuration.md
+++ b/docs/articles/mcp-configuration.md
@@ -147,35 +147,11 @@ Look at my recent test failures and help me understand what's causing them. Chec
 
 For direct interaction with Claude through the desktop application.
 
-#### Using the Hosted Endpoint (Recommended)
+:::warning Claude Desktop Limitation
+Claude Desktop's `claude_desktop_config.json` only supports **local stdio servers** (`command` + `args`). It does not support remote MCP servers configured directly in the config file. To connect to a remote MCP server, use the CLI or Docker options below, or add the server via **Settings → Integrations** in Claude Desktop.
+:::
 
-1. **Create or edit Claude Desktop config:**
-
-   **Location:** `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
-
-   ```json
-   {
-     "mcpServers": {
-       "testkube": {
-         "url": "https://api.testkube.io/organizations/tkcorg_YOUR_ORG_ID/environments/tkcenv_YOUR_ENV_ID/mcp",
-         "transport": {
-           "type": "sse"
-         },
-         "headers": {
-           "Authorization": "Bearer YOUR_API_TOKEN_HERE"
-         }
-       }
-     }
-   }
-   ```
-
-   Replace `tkcorg_YOUR_ORG_ID`, `tkcenv_YOUR_ENV_ID`, and `YOUR_API_TOKEN_HERE` with your actual values.
-   
-   **[Learn more about the hosted endpoint →](./mcp-hosted)**
-
-2. **Restart Claude Desktop**
-
-#### Using the CLI
+#### Using the CLI (Recommended)
 
 1. **Create or edit Claude Desktop config:**
 
@@ -193,6 +169,35 @@ For direct interaction with Claude through the desktop application.
    ```
 
    **[Learn more about CLI setup →](./mcp-cli)**
+
+2. **Restart Claude Desktop**
+
+#### Using Docker
+
+1. **Create or edit Claude Desktop config:**
+
+   **Location:** `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
+
+   ```json
+   {
+     "mcpServers": {
+       "testkube": {
+         "command": "docker",
+         "args": [
+           "run", "--rm", "-i",
+           "-e", "TK_ACCESS_TOKEN=YOUR_API_TOKEN_HERE",
+           "-e", "TK_ORG_ID=tkcorg_YOUR_ORG_ID",
+           "-e", "TK_ENV_ID=tkcenv_YOUR_ENV_ID",
+           "kubeshop/testkube-mcp-server:latest", "mcp", "serve"
+         ]
+       }
+     }
+   }
+   ```
+
+   Replace `tkcorg_YOUR_ORG_ID`, `tkcenv_YOUR_ENV_ID`, and `YOUR_API_TOKEN_HERE` with your actual values.
+
+   **[Learn more about Docker setup →](./mcp-docker)**
 
 2. **Restart Claude Desktop**
 

--- a/docs/articles/mcp-hosted.md
+++ b/docs/articles/mcp-hosted.md
@@ -21,7 +21,7 @@ This is the easiest way to get started with the Testkube MCP Server - no local i
 
 - **Access to a Testkube Environment** - You need an active Testkube organization and environment
 - **API Token** - A valid Testkube API token with appropriate permissions
-- **An AI tool that supports MCP with SSE transport** - Such as Claude Desktop, Cursor, VS Code with GitHub Copilot, or custom MCP clients
+- **An AI tool that supports remote MCP servers** - Such as Cursor, VS Code with GitHub Copilot, or custom MCP clients. Note: Claude Desktop does not support remote MCP servers via its config file — use the [CLI](./mcp-cli) or [Docker](./mcp-docker) setup instead
 
 ## Endpoint URL Structure
 


### PR DESCRIPTION
## Summary
- Remove incorrect hosted endpoint (URL + SSE) config for Claude Desktop — claude_desktop_config.json only supports local stdio servers
- Add warning callout explaining the limitation
- Add Docker stdio config as an alternative to CLI
- Fix mcp-hosted.md prerequisites to not list Claude Desktop as SSE-compatible

Resolves TKC-5601