### PR TITLE
chore: cleanup

### DIFF
--- a/docs/articles/ai-configuration.mdx
+++ b/docs/articles/ai-configuration.mdx
@@ -51,10 +51,6 @@ Self-hosted installations require additional infrastructure and configuration ap
 A PostgreSQL database is required for LangGraph checkpointing (conversation persistence). Configure the database connection 
 via `POSTGRES_URI` environment variable or Helm `db.secretRef` configuration.
 
-:::note
-This DB is separate from the main Testkube database and is used solely for AI functionality - you can still use PostgreSQL for your main Testkube database (recommended).
-:::
-
 ### Helm Configuration
 
 Configure the following components in your `testkube-enterprise` Helm values:

--- a/docs/articles/ai-configuration.mdx
+++ b/docs/articles/ai-configuration.mdx
@@ -52,7 +52,7 @@ A PostgreSQL database is required for LangGraph checkpointing (conversation pers
 via `POSTGRES_URI` environment variable or Helm `db.secretRef` configuration.
 
 :::note
-This DB is separate from the main Testkube database and is used solely for AI functionality - you can still use MongoDB for your main Testkube database (recommended).
+This DB is separate from the main Testkube database and is used solely for AI functionality - you can still use PostgreSQL for your main Testkube database (recommended).
 :::
 
 ### Helm Configuration
@@ -390,4 +390,3 @@ testkube-ai-service:
 - [AI Agent Triggers](/articles/ai-triggers) — Automating agent execution on workflow events
 - [Configuring AI Models](/articles/ai-models) — Adding custom models from the Dashboard
 - [AI Architecture](/articles/ai-architecture) — How Testkube AI components work together
-

--- a/docs/articles/ai-enabling.mdx
+++ b/docs/articles/ai-enabling.mdx
@@ -25,7 +25,7 @@ in the Dashboard as described above.
 
 **Prerequisites:**
 - OpenAI API key (or compatible LLM API)
-- PostgreSQL database (for conversation persistence) - this can live alongside MongoDB as your main Testkube database.
+- PostgreSQL database (for conversation persistence) - this can live alongside your main Testkube PostgreSQL database.
 
 ```yaml
 testkube-ai-service:

--- a/docs/articles/architecture.md
+++ b/docs/articles/architecture.md
@@ -84,7 +84,7 @@ expose ports for both HTTPS and WSS endpoints.
 The main infrastructure dependencies required by the Control Plane are:
 
 - NATS
-- MongoDB - [Read more](mongodb-administration) or PostgreSQL
+- PostgreSQL - [Read more](mongodb-administration)
 - S3 (via Minio)
 - Dex for federated authentication
 
@@ -100,7 +100,7 @@ flowchart TB
 
     subgraph Infrastructure Dependencies
         Dex["Dex - 5556, 5557"]
-        DB[("MongoDB / PostgreSQL")]
+        DB[("PostgreSQL")]
         NATS["NATS - 4222"]
         S3["S3 / MinIO - 9000"]
     end

--- a/docs/articles/ha.md
+++ b/docs/articles/ha.md
@@ -129,11 +129,9 @@ a different node and reconnecting.
 - The operator can only run as a single instance, but it is responsible for
   running a periodic reconciliation process which at most could be delayed while
 a new pod spawns on a different node.
-- Setting up MongoDB for high availability is outside of the scope of this
+- Setting up PostgreSQL for high availability is outside of the scope of this
   guide, but in production deployments we highly recommend utilizing a managed service
-such as [MongoDB
-Atlas](https://www.mongodb.com/products/platform/atlas-database) as an [external
-MongoDB cluster](./mongodb-administration#using-an-external-mongodb-instance).
+or operator-backed deployment for PostgreSQL. MongoDB-based legacy deployments should continue using an [external MongoDB cluster](./mongodb-administration#using-an-external-mongodb-instance).
 - Dex should be backed by an highly available data storage like
   [etcd](https://dexidp.io/docs/configuration/storage/#etcd).
 - The NATS chart is currently missing the ability to specify `tolerations` and

--- a/docs/articles/helm-components.md
+++ b/docs/articles/helm-components.md
@@ -12,32 +12,29 @@ for your specific needs.
 
 The central component that manages connected Agents.
 * API - A service which runs the REST, Agent gRPC and Websocket APIs for interacting with the Control Plane.
-    * Helm chart - Bundled as a subchart in the [testkube-enterprise](https://github.com/kubeshop/testkube-cloud-charts/tree/main/charts/testkube-enterprise) Helm chart.
     * Docker image - [kubeshop/testkube-enterprise-api](https://hub.docker.com/r/kubeshop/testkube-enterprise-api)
 * Dashboard - The web-based UI for managing tests, environments, and users.
-    * Helm chart - Bundled as a subchart in the [testkube-enterprise](https://github.com/kubeshop/testkube-cloud-charts/tree/main/charts/testkube-enterprise) Helm chart.
     * Docker image - [kubeshop/testkube-enterprise-ui](https://hub.docker.com/r/kubeshop/testkube-enterprise-ui)
 * Worker Service - A service which handles async operations for artifacts and test executions.
-    * Helm chart - Bundled as a subchart in the [testkube-enterprise](https://github.com/kubeshop/testkube-cloud-charts/tree/main/charts/testkube-enterprise) Helm chart.
     * Docker image - [kubeshop/testkube-enterprise-worker-service](https://hub.docker.com/r/kubeshop/testkube-enterprise-worker-service)
 * Dex - A service that is used as an identity provider.
-    * Helm chart - Bundled as a subchart in the [testkube-enterprise](https://github.com/kubeshop/testkube-cloud-charts/tree/main/charts/testkube-enterprise) Helm chart.
-    * Docker image - [dex](https://github.com/dexidp/dex/pkgs/container/dex)
+    * Docker image - [kubeshop/dex](https://hub.docker.com/r/kubeshop/dex)
 * Minio - It is a database that is used for storing artifacts.
-    * Helm chart - Used as a bitnami subchart in the [testkube-enterprise](https://github.com/kubeshop/testkube-cloud-charts/tree/main/charts/testkube-enterprise) Helm chart.
-    * Docker image - [MinIo](https://hub.docker.com/r/bitnami/minio/tags)
-* MongoDB - It is a database that is used for storing the data.
-    * Helm chart - Used as a bitnami subchart in the [testkube-enterprise](https://github.com/kubeshop/testkube-cloud-charts/tree/main/charts/testkube-enterprise) Helm chart.
-    * Docker image - [MongoDB](https://hub.docker.com/r/bitnami/mongodb/tags)
-* PostgreSQL - It is a database that is used for storing the data.
-    * Helm chart - Used as a bitnami subchart in the [testkube-enterprise](https://github.com/kubeshop/testkube-cloud-charts/tree/main/charts/testkube-enterprise) Helm chart.
-    * Docker image - [PostgreSQL](https://hub.docker.com/r/bitnami/postgresql/tags)   
+    * Helm chart - Maintained in the [testkube-thirdparty-artifacts](https://github.com/kubeshop/testkube-thirdparty-artifacts) repository.
+    * Docker image - [kubeshop/testkube-minio](https://hub.docker.com/r/kubeshop/testkube-minio)
+* PostgreSQL - It is the primary database used for storing Testkube data.
+    * Recommended deployment - Use the native [CloudNativePG](https://cloudnative-pg.io/) operator for PostgreSQL lifecycle management in Kubernetes.
+    * Helm chart - If needed, supporting artifacts are maintained in the [testkube-thirdparty-artifacts](https://github.com/kubeshop/testkube-thirdparty-artifacts) repository for legacy or transitional setups.
+    * Docker image - [kubeshop/testkube-postgres](https://hub.docker.com/r/kubeshop/testkube-postgres)
+* MongoDB - Legacy database support retained for existing installations and migration workflows.
+    * Helm chart - Maintained in the [testkube-thirdparty-artifacts](https://github.com/kubeshop/testkube-thirdparty-artifacts) repository.
+    * Docker image - [kubeshop/bitnami-mongodb](https://hub.docker.com/r/kubeshop/bitnami-mongodb)
 * NATS - It is a service that is used as a message broker for communication between API and Agents.
-    * Helm chart - Used as a NATS subchart in the [testkube-enterprise](https://github.com/kubeshop/testkube-cloud-charts/tree/main/charts/testkube-enterprise) Helm chart.
+    * Helm chart - Maintained in the [testkube-thirdparty-artifacts](https://github.com/kubeshop/testkube-thirdparty-artifacts) repository.
     * Docker image - [NATS](https://hub.docker.com/_/nats/tags)
 * Additional images used for running jobs during the chart install:
     * [kubectl](https://hub.docker.com/r/bitnami/kubectl)
-    * [mongosh](https://hub.docker.com/r/alpine/mongosh)
+    * [mongosh](https://hub.docker.com/r/alpine/mongosh) for legacy MongoDB operations
     * [db-migrations](https://hub.docker.com/repository/docker/kubeshop/testkube-enterprise-api-migrations/tags)
     * [nats-reloader](https://hub.docker.com/r/natsio/nats-server-config-reloader)
     * [natsBox](https://hub.docker.com/r/natsio/nats-box)

--- a/docs/articles/install/standalone-agent.md
+++ b/docs/articles/install/standalone-agent.md
@@ -239,7 +239,7 @@ Alternatively, these values can be read from Kubernetes secrets and set:
 
 To install the standalone agent Testkube on an Openshift cluster you will need to include the following configuration:
 
-1. Add security context for PostgreSQL to `values.yaml` (and MongoDB only if you are maintaining a legacy deployment):
+1. Add security context for MongoDB to `values.yaml`:
 
 ```yaml
 mongodb:

--- a/docs/articles/install/standalone-agent.md
+++ b/docs/articles/install/standalone-agent.md
@@ -51,7 +51,7 @@ The following steps are required to install the Standalone Agent into a Kubernet
 
 - Create a Testkube namespace.
 - Deploy the Testkube API (see below).
-- Use MongoDB or PostgreSQL for test results and Minio for artifact storage (optional; disable with --no-minio).
+- Use PostgreSQL as the primary database for test results, with MongoDB still supported for legacy deployments, and Minio for artifact storage (optional; disable with --no-minio).
 - In standalone mode, Testkube will listen and manage all the CRDs for TestWorkflows, Triggers, Webhooks, etc. inside the Testkube namespace. In connected mode (v2.7+), resources are managed by the Control Plane instead - [Read More](/articles/testkube-resource-management).
 
 Once installed you can verify your installation and check that Testkube is up and running with
@@ -239,7 +239,7 @@ Alternatively, these values can be read from Kubernetes secrets and set:
 
 To install the standalone agent Testkube on an Openshift cluster you will need to include the following configuration:
 
-1. Add security context for MongoDB or PostgreSQL to `values.yaml`:
+1. Add security context for PostgreSQL to `values.yaml` (and MongoDB only if you are maintaining a legacy deployment):
 
 ```yaml
 mongodb:

--- a/docs/articles/mongodb-administration.md
+++ b/docs/articles/mongodb-administration.md
@@ -1,8 +1,12 @@
 # MongoDB administration
 
+:::note
+PostgreSQL is the primary database for current Testkube installations. This page is kept for teams that still operate MongoDB-based deployments or are preparing a migration to PostgreSQL.
+:::
+
 ## Using an external MongoDB instance
 
-MongoDB is used for storage of Testkube Test results and various Testkube configurations as telemetry settings and cluster ID.
+MongoDB is used for storage of Testkube Test results and various Testkube configurations as telemetry settings and cluster ID in legacy MongoDB-based deployments.
 
 In order to use an external MongoDB instance, follow these steps:
 
@@ -15,6 +19,10 @@ kubectl testkube install --set mongo.enabled=false
 ```
 
 3. [Update MongoDB details for the api-server in the Helm values with valid connection string](/articles/install/advanced-install#mongodb).
+
+:::tip
+For new installations, prefer PostgreSQL and the guidance in [advanced install](/articles/install/advanced-install#postgresql) or [standalone agent PostgreSQL setup](/articles/install/standalone-agent#using-postgresql-as-a-database).
+:::
 
 ### SSL Connections
 

--- a/docs/articles/open-source.md
+++ b/docs/articles/open-source.md
@@ -23,7 +23,7 @@ the Testkube Agent in Standalone and Connected modes.
 As described in the [Standalone Agent Overview](/articles/install/standalone-agent#running-in-standalone-mode), in standalone mode the agent
 
 - Manages all Testkube Resources as CRDs in the cluster/namespace where it is deployed.
-- Schedules and executes your Test Workflows and collects execution logs and artifacts into configured PostgreSQL as the primary database, with MongoDB support still available for legacy deployments, and S3-compatible storage.
+- Schedules and executes your Test Workflows and collects execution logs and artifacts into configured PostgreSQL, and S3-compatible storage.
 - Listens to Kubernetes Events for Event Triggers.
 - Emits Webhooks and CDEvents as configured.
 

--- a/docs/articles/open-source.md
+++ b/docs/articles/open-source.md
@@ -23,7 +23,7 @@ the Testkube Agent in Standalone and Connected modes.
 As described in the [Standalone Agent Overview](/articles/install/standalone-agent#running-in-standalone-mode), in standalone mode the agent
 
 - Manages all Testkube Resources as CRDs in the cluster/namespace where it is deployed.
-- Schedules and executes your Test Workflows and collects execution logs and artifacts into configured MongoDB and S3 storage.
+- Schedules and executes your Test Workflows and collects execution logs and artifacts into configured PostgreSQL as the primary database, with MongoDB support still available for legacy deployments, and S3-compatible storage.
 - Listens to Kubernetes Events for Event Triggers.
 - Emits Webhooks and CDEvents as configured.
 

--- a/docs/articles/repackaging-testkube.md
+++ b/docs/articles/repackaging-testkube.md
@@ -101,7 +101,7 @@ EXPOSE 8080
 
 Testkube has some dependencies on other components such as:
 
-- MongoDB or PostgreSQL
+- PostgreSQL as the primary database, with MongoDB still present for legacy deployments and migration scenarios
 - Minio
 - NATS
 - Dex

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -129,7 +129,7 @@ Updated image registry references in Helm values: container images are now sourc
 #### PostgreSQL
 
 - Added support for supplying the PostgreSQL DSN from Kubernetes secrets for all Testkube services.
-- Added support for running PostgreSQL with CloudNativePG, alongside the existing bundled PostgreSQL deployment to preserve backward compatibility. This includes support for installing the CloudNativePG operator and provisioning an operator-managed PostgreSQL cluster. Read more: PostgreSQL
+- Added support for running PostgreSQL with CloudNativePG, alongside the existing bundled PostgreSQL deployment to preserve backward compatibility. This includes support for installing the CloudNativePG operator and provisioning an operator-managed PostgreSQL cluster. [Read more](/articles/install/advanced-install#postgresql).
 - Added migration command to migrate MongoDB to PostgreSQL - [Read more](/articles/convert)
 
 #### Solve vulnerabilities


### PR DESCRIPTION
## Changes
- replaced outdated testkube-cloud-charts references with testkube-thirdparty-artifacts
- updated image references for PostgreSQL, MongoDB, MinIO, and Dex
- clarified that PostgreSQL is recommended via the CloudNativePG operator rather than chart-based installation

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
