### PR TITLE
fix: remove incorrect transport.type SSE from MCP config examples

### DIFF
--- a/docs/articles/mcp-configuration.md
+++ b/docs/articles/mcp-configuration.md
@@ -147,35 +147,11 @@ Look at my recent test failures and help me understand what's causing them. Chec
 
 For direct interaction with Claude through the desktop application.
 
-#### Using the Hosted Endpoint (Recommended)
+:::warning Claude Desktop Limitation
+Claude Desktop's `claude_desktop_config.json` only supports **local stdio servers** (`command` + `args`). It does not support remote MCP servers configured directly in the config file. To connect to a remote MCP server, use the CLI or Docker options below, or add the server via **Settings → Integrations** in Claude Desktop.
+:::
 
-1. **Create or edit Claude Desktop config:**
-
-   **Location:** `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
-
-   ```json
-   {
-     "mcpServers": {
-       "testkube": {
-         "url": "https://api.testkube.io/organizations/tkcorg_YOUR_ORG_ID/environments/tkcenv_YOUR_ENV_ID/mcp",
-         "transport": {
-           "type": "sse"
-         },
-         "headers": {
-           "Authorization": "Bearer YOUR_API_TOKEN_HERE"
-         }
-       }
-     }
-   }
-   ```
-
-   Replace `tkcorg_YOUR_ORG_ID`, `tkcenv_YOUR_ENV_ID`, and `YOUR_API_TOKEN_HERE` with your actual values.
-   
-   **[Learn more about the hosted endpoint →](./mcp-hosted)**
-
-2. **Restart Claude Desktop**
-
-#### Using the CLI
+#### Using the CLI (Recommended)
 
 1. **Create or edit Claude Desktop config:**
 
@@ -193,6 +169,35 @@ For direct interaction with Claude through the desktop application.
    ```
 
    **[Learn more about CLI setup →](./mcp-cli)**
+
+2. **Restart Claude Desktop**
+
+#### Using Docker
+
+1. **Create or edit Claude Desktop config:**
+
+   **Location:** `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
+
+   ```json
+   {
+     "mcpServers": {
+       "testkube": {
+         "command": "docker",
+         "args": [
+           "run", "--rm", "-i",
+           "-e", "TK_ACCESS_TOKEN=YOUR_API_TOKEN_HERE",
+           "-e", "TK_ORG_ID=tkcorg_YOUR_ORG_ID",
+           "-e", "TK_ENV_ID=tkcenv_YOUR_ENV_ID",
+           "kubeshop/testkube-mcp-server:latest", "mcp", "serve"
+         ]
+       }
+     }
+   }
+   ```
+
+   Replace `tkcorg_YOUR_ORG_ID`, `tkcenv_YOUR_ENV_ID`, and `YOUR_API_TOKEN_HERE` with your actual values.
+
+   **[Learn more about Docker setup →](./mcp-docker)**
 
 2. **Restart Claude Desktop**
 

--- a/docs/articles/mcp-configuration.md
+++ b/docs/articles/mcp-configuration.md
@@ -24,9 +24,6 @@ GitHub Copilot with Agent mode in VS Code provides excellent agentic capabilitie
      "mcpServers": {
        "testkube": {
          "url": "https://api.testkube.io/organizations/tkcorg_YOUR_ORG_ID/environments/tkcenv_YOUR_ENV_ID/mcp",
-         "transport": {
-           "type": "sse"
-         },
          "headers": {
            "Authorization": "Bearer YOUR_API_TOKEN_HERE"
          }
@@ -98,9 +95,6 @@ Add the hosted endpoint configuration to your Cursor MCP settings:
   "mcpServers": {
     "testkube": {
       "url": "https://api.testkube.io/organizations/tkcorg_YOUR_ORG_ID/environments/tkcenv_YOUR_ENV_ID/mcp",
-      "transport": {
-        "type": "sse"
-      },
       "headers": {
         "Authorization": "Bearer YOUR_API_TOKEN_HERE"
       }

--- a/docs/articles/mcp-hosted.md
+++ b/docs/articles/mcp-hosted.md
@@ -21,7 +21,7 @@ This is the easiest way to get started with the Testkube MCP Server - no local i
 
 - **Access to a Testkube Environment** - You need an active Testkube organization and environment
 - **API Token** - A valid Testkube API token with appropriate permissions
-- **An AI tool that supports MCP with SSE transport** - Such as Claude Desktop, Cursor, VS Code with GitHub Copilot, or custom MCP clients
+- **An AI tool that supports remote MCP servers** - Such as Cursor, VS Code with GitHub Copilot, or custom MCP clients. Note: Claude Desktop does not support remote MCP servers via its config file — use the [CLI](./mcp-cli) or [Docker](./mcp-docker) setup instead
 
 ## Endpoint URL Structure
 

--- a/docs/articles/mcp-hosted.md
+++ b/docs/articles/mcp-hosted.md
@@ -47,16 +47,13 @@ testkube get context
 
 ## Configuration Example
 
-To use the Control Plane MCP endpoint with an AI tool that supports SSE (Server-Sent Events) transport:
+To use the Control Plane MCP endpoint with an AI tool that supports remote MCP servers:
 
 ```json
 {
   "mcpServers": {
     "testkube": {
       "url": "https://api.testkube.io/organizations/tkcorg_076487a004a7f6fb/environments/tkcenv_d19e797ff2c1449b/mcp",
-      "transport": {
-        "type": "sse"
-      },
       "headers": {
         "Authorization": "Bearer YOUR_API_TOKEN_HERE"
       }
@@ -132,9 +129,6 @@ For self-hosted instances, use your custom control plane URL in the MCP configur
   "mcpServers": {
     "testkube": {
       "url": "https://your-control-plane.example.com/organizations/{organization_id}/environments/{environment_id}/mcp",
-      "transport": {
-        "type": "sse"
-      },
       "headers": {
         "Authorization": "Bearer YOUR_API_TOKEN_HERE"
       }

--- a/docs/articles/mcp-security.md
+++ b/docs/articles/mcp-security.md
@@ -24,9 +24,6 @@ This means the MCP Server operates within your existing security boundaries - it
   "mcpServers": {
     "testkube": {
       "url": "https://api.testkube.io/organizations/{org_id}/environments/{env_id}/mcp",
-      "transport": {
-        "type": "sse"
-      },
       "headers": {
         "Authorization": "Bearer YOUR_API_TOKEN"
       }


### PR DESCRIPTION
## Context

Ole flagged that MCP configuration examples include an incorrect `"transport": { "type": "sse" }` block. The `url` field is sufficient — clients infer the transport automatically.

Thread: https://kubeshop.slack.com/archives/C0AUC5FBA1J/p1777496979120119

## Changes

Removes the `transport` block from all MCP config examples across 3 files (5 occurrences):

| File | Section |
|------|---------|
| `mcp-configuration.md` | VS Code config |
| `mcp-configuration.md` | Cursor config |
| `mcp-hosted.md` | Configuration example |
| `mcp-hosted.md` | Self-hosted config |
| `mcp-security.md` | API tokens section |

Also updates the description in `mcp-hosted.md` from "SSE (Server-Sent Events) transport" to "remote MCP servers".

Companion PR for the in-app examples: https://github.com/kubeshop/testkube-cloud-api/pull/3645