### PR TITLE
docs(TKC-5447): add OAuth authentication to MCP docs

### DIFF
--- a/docs/articles/ai-configuration.mdx
+++ b/docs/articles/ai-configuration.mdx
@@ -44,12 +44,9 @@ For On-Prem installations, you can configure your own OpenAI API Key or use a di
 
 Self-hosted installations require additional infrastructure and configuration apart from the above Cloud Control Plane configuration.
 
-### Infrastructure Requirements
-
-#### PostgreSQL Database
-
-A PostgreSQL database is required for LangGraph checkpointing (conversation persistence). Configure the database connection 
-via `POSTGRES_URI` environment variable or Helm `db.secretRef` configuration.
+:::note PostgreSQL
+The AI service uses PostgreSQL for conversation persistence (LangGraph checkpointing). It shares the control plane's PostgreSQL instance by default — no additional database infrastructure is required.
+:::
 
 ### Helm Configuration
 

--- a/docs/articles/mcp-configuration.md
+++ b/docs/articles/mcp-configuration.md
@@ -13,11 +13,30 @@ Before configuring your AI tools, make sure you've set up the Testkube MCP Serve
 
 GitHub Copilot with Agent mode in VS Code provides excellent agentic capabilities for multi-step testing workflows.
 
-### Using the Hosted Endpoint (Recommended)
+### Using the Hosted Endpoint with OAuth (Recommended)
 
 1. **Create or edit your MCP configuration file:**
 
    **Location:** `~/Library/Application Support/Code/User/mcp.json` (macOS) or `%APPDATA%\Code\User\mcp.json` (Windows)
+
+   ```json
+   {
+     "servers": {
+       "testkube": {
+         "type": "http",
+         "url": "https://api.testkube.io/organizations/tkcorg_YOUR_ORG_ID/environments/tkcenv_YOUR_ENV_ID/mcp"
+       }
+     }
+   }
+   ```
+
+   Replace `tkcorg_YOUR_ORG_ID` and `tkcenv_YOUR_ENV_ID` with your actual values. No API token needed — VS Code handles OAuth authentication automatically via a browser login.
+
+   **[Learn more about the hosted endpoint →](./mcp-hosted)**
+
+### Using the Hosted Endpoint with API Token
+
+   If you prefer using an API token (e.g., for shared or automated setups):
 
    ```json
    {
@@ -36,8 +55,6 @@ GitHub Copilot with Agent mode in VS Code provides excellent agentic capabilitie
    ```
 
    Replace `tkcorg_YOUR_ORG_ID`, `tkcenv_YOUR_ENV_ID`, and `YOUR_API_TOKEN_HERE` with your actual values.
-   
-   **[Learn more about the hosted endpoint →](./mcp-hosted)**
 
 2. **Restart VS Code** to load the new configuration
 
@@ -147,8 +164,12 @@ Look at my recent test failures and help me understand what's causing them. Chec
 
 For direct interaction with Claude through the desktop application.
 
-:::warning Claude Desktop Limitation
-Claude Desktop's `claude_desktop_config.json` only supports **local stdio servers** (`command` + `args`). It does not support remote MCP servers configured directly in the config file. To connect to a remote MCP server, use the CLI or Docker options below, or add the server via **Settings → Integrations** in Claude Desktop.
+#### Using the Hosted Endpoint with OAuth
+
+You can add the Testkube MCP server via **Settings → Connectors → Add custom connector** in Claude Desktop. Paste the endpoint URL and Claude Desktop handles OAuth authentication automatically — you'll see a browser popup to log in.
+
+:::info
+Claude Desktop's `claude_desktop_config.json` only supports **local stdio servers** (`command` + `args`). To use the hosted endpoint with OAuth, add it as a custom connector via Settings → Connectors, or use the CLI/Docker options below.
 :::
 
 #### Using the CLI (Recommended)
@@ -203,10 +224,20 @@ Claude Desktop's `claude_desktop_config.json` only supports **local stdio server
 
 ### Claude Code
 
-Use the following to add the Docker MCP Server to Claude Code
+#### Using the Hosted Endpoint with OAuth (Recommended)
 
 ```bash
-claude mcp add testkube -- docker run --rm -i \ 
+claude mcp add --transport http testkube https://api.testkube.io/organizations/tkcorg_YOUR_ORG_ID/environments/tkcenv_YOUR_ENV_ID/mcp
+```
+
+Claude Code handles OAuth automatically — a browser window opens for you to log in. No tokens needed.
+
+**[Learn more about the hosted endpoint →](./mcp-hosted)**
+
+#### Using Docker
+
+```bash
+claude mcp add testkube -- docker run --rm -i \
    -e TK_ACCESS_TOKEN=${TK_ACCESS_TOKEN} \
    -e TK_ORG_ID=${TK_ORG_ID} \
    -e TK_ENV_ID=${TK_ENV_ID} \

--- a/docs/articles/mcp-hosted.md
+++ b/docs/articles/mcp-hosted.md
@@ -20,8 +20,24 @@ This is the easiest way to get started with the Testkube MCP Server - no local i
 ## Prerequisites
 
 - **Access to a Testkube Environment** - You need an active Testkube organization and environment
-- **API Token** - A valid Testkube API token with appropriate permissions
-- **An AI tool that supports remote MCP servers** - Such as Cursor, VS Code with GitHub Copilot, or custom MCP clients. Note: Claude Desktop does not support remote MCP servers via its config file — use the [CLI](./mcp-cli) or [Docker](./mcp-docker) setup instead
+- **An AI tool that supports MCP** - Such as Claude Code, VS Code with GitHub Copilot, Cursor, or Claude Desktop
+
+## Authentication
+
+The hosted MCP endpoint supports two authentication methods:
+
+### OAuth (Recommended)
+
+OAuth lets MCP clients authenticate through your browser — no tokens to create or manage. Your MCP client handles discovery and authentication automatically. You just see a browser popup to log in.
+
+This is the recommended approach for individual users because:
+- No API keys to create, copy, or rotate
+- Per-user identity for seat tracking and audit trails
+- Works with your existing SSO provider (Google, GitHub, SAML, etc.)
+
+### API Token
+
+API tokens are better for automation, CI/CD, or shared environments where browser login isn't practical. See [Obtaining an API Token](#obtaining-an-api-token) below.
 
 ## Endpoint URL Structure
 
@@ -45,15 +61,44 @@ testkube get context
 
 :::
 
-## Configuration Example
+## Configuration with OAuth
 
-To use the Control Plane MCP endpoint with an AI tool that supports SSE (Server-Sent Events) transport:
+With OAuth, you just provide the endpoint URL. No headers, no tokens — your MCP client handles authentication automatically via a browser login.
+
+### Claude Code
+
+```bash
+claude mcp add --transport http testkube https://api.testkube.io/organizations/{organization_id}/environments/{environment_id}/mcp
+```
+
+### VS Code (GitHub Copilot)
+
+Add to your MCP settings (`~/Library/Application Support/Code/User/mcp.json` on macOS):
+
+```json
+{
+  "servers": {
+    "testkube": {
+      "type": "http",
+      "url": "https://api.testkube.io/organizations/{organization_id}/environments/{environment_id}/mcp"
+    }
+  }
+}
+```
+
+### Cursor / Claude Desktop
+
+These clients also support OAuth automatically. Add a remote MCP server with the endpoint URL — the client will handle the OAuth flow.
+
+## Configuration with API Token
+
+If you prefer API tokens (for automation or shared environments), provide the token in the headers:
 
 ```json
 {
   "mcpServers": {
     "testkube": {
-      "url": "https://api.testkube.io/organizations/tkcorg_076487a004a7f6fb/environments/tkcenv_d19e797ff2c1449b/mcp",
+      "url": "https://api.testkube.io/organizations/{organization_id}/environments/{environment_id}/mcp",
       "transport": {
         "type": "sse"
       },
@@ -67,8 +112,8 @@ To use the Control Plane MCP endpoint with an AI tool that supports SSE (Server-
 
 Replace:
 
-- `tkcorg_076487a004a7f6fb` with your actual organization ID
-- `tkcenv_d19e797ff2c1449b` with your actual environment ID
+- `{organization_id}` with your actual organization ID
+- `{environment_id}` with your actual environment ID
 - `YOUR_API_TOKEN_HERE` with your Testkube API token
 
 ## Obtaining an API Token
@@ -114,7 +159,15 @@ testkube-cloud-ui:
     MCP_ENABLED: true
 ```
 
-### Step 2: Enable MCP per Environment
+### Step 2: Register the OAuth Callback in Dex
+
+To enable OAuth authentication for the MCP endpoint, add the MCP OAuth callback URL to your Dex configuration's `redirectURIs` for the `testkube-enterprise` client:
+
+```yaml
+- 'https://your-api-domain.example.com/mcp/auth/callback'
+```
+
+### Step 3: Enable MCP per Environment
 
 After deploying with MCP enabled, you need to enable it for each environment:
 
@@ -123,9 +176,24 @@ After deploying with MCP enabled, you need to enable it for each environment:
 3. Toggle the **MCP Endpoint** switch to "Enabled"
 4. Copy the configuration for your preferred IDE
 
-### Step 3: Configure Your AI Tool
+### Step 4: Configure Your AI Tool
 
-For self-hosted instances, use your custom control plane URL in the MCP configuration:
+For self-hosted instances, use your custom control plane URL:
+
+**With OAuth (recommended):**
+
+```json
+{
+  "servers": {
+    "testkube": {
+      "type": "http",
+      "url": "https://your-control-plane.example.com/organizations/{organization_id}/environments/{environment_id}/mcp"
+    }
+  }
+}
+```
+
+**With API Token:**
 
 ```json
 {
@@ -143,9 +211,4 @@ For self-hosted instances, use your custom control plane URL in the MCP configur
 }
 ```
 
-Replace:
-
-- `your-control-plane.example.com` with your self-hosted control plane domain
-- `{organization_id}` with your organization ID
-- `{environment_id}` with your environment ID
-- `YOUR_API_TOKEN_HERE` with your API token
+Replace `your-control-plane.example.com` with your self-hosted control plane domain, and use your actual organization ID, environment ID, and API token.

--- a/docs/articles/mcp-overview.md
+++ b/docs/articles/mcp-overview.md
@@ -40,9 +40,10 @@ Choose the setup method that works best for you:
 **The easiest way to get started** - Connect directly to the Testkube Control Plane without any local installation.
 
 - ✅ No installation required
+- ✅ OAuth authentication — just log in via browser, no API keys needed
 - ✅ Always available
 - ✅ Best for remote access and team collaboration
-- ✅ Works with any AI tool that supports SSE transport
+- ✅ Works with Claude Code, VS Code, Cursor, and other MCP clients
 
 **[Get Started with Hosted Endpoint →](./mcp-hosted)**
 

--- a/docs/articles/mcp-security.md
+++ b/docs/articles/mcp-security.md
@@ -4,20 +4,49 @@ The **Testkube MCP Server** integrates with your existing Testkube security infr
 
 ## How MCP Server Works Securely
 
-The MCP Server performs actions on behalf of users or services using API tokens or user credentials:
+The MCP Server performs actions on behalf of users or services using authenticated credentials:
 
-- **Authentication**: Uses API tokens or user JWT tokens
+- **Authentication**: Uses OAuth, API tokens, or user JWT tokens
 - **Authorization**: Respects all [Role-Based Access Control](/articles/environments-best-practices) (RBAC) policies
 - **Audit Logging**: All actions are logged in [Audit Logs](/articles/audit-logs)
-- **Token Scopes**: API tokens can be scoped to specific environments and permissions
+- **Per-User Identity**: OAuth tokens are tied to individual users for seat tracking and attribution
 
 This means the MCP Server operates within your existing security boundaries - it cannot access resources the user or API token doesn't have permission for.
 
 ## Authentication Methods
 
-### API Tokens (Recommended for MCP)
+### OAuth (Recommended for Individual Users)
 
-[API Tokens](/articles/api-token-management) provide machine-to-machine authentication ideal for MCP Server usage:
+The hosted MCP endpoint supports OAuth authentication via the [MCP authorization spec](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization). MCP clients like Claude Code, VS Code, and Cursor handle the OAuth flow automatically — you just see a browser popup to log in through your organization's identity provider (Google, GitHub, SAML, etc.).
+
+**Advantages:**
+- No API keys to create, copy, or rotate
+- Per-user identity — each user authenticates individually
+- Enables seat-based licensing and audit trails
+- Works with existing SSO providers via Dex
+
+**How it works:**
+1. Your MCP client discovers the OAuth metadata at `/.well-known/oauth-protected-resource`
+2. The client registers itself (via CIMD or DCR) and redirects you to log in
+3. After login, the gateway issues a short-lived access token and refresh token
+4. The client automatically refreshes tokens as needed
+
+```json
+{
+  "servers": {
+    "testkube": {
+      "type": "http",
+      "url": "https://api.testkube.io/organizations/{org_id}/environments/{env_id}/mcp"
+    }
+  }
+}
+```
+
+No `headers` or `Authorization` needed — the client handles everything.
+
+### API Tokens (Recommended for Automation)
+
+[API Tokens](/articles/api-token-management) provide machine-to-machine authentication ideal for CI/CD pipelines, shared environments, or automated workflows where browser login isn't practical:
 
 ```json
 {
@@ -54,7 +83,7 @@ When using the CLI or Docker setup, the MCP Server uses the authenticated user's
 
 When using the hosted MCP endpoint (`https://api.testkube.io/.../mcp`):
 
-- Requests are authenticated using your API token
+- Requests are authenticated using OAuth or your API token
 - Data flows through Testkube's Control Plane infrastructure
 - All standard security controls apply (authentication, authorization, audit logging)
 
@@ -78,6 +107,14 @@ Create API tokens with the minimum required permissions:
 - Use **Run** permissions when you need to execute workflows
 - Use **Write** permissions only when creating or modifying resources
 
+### Use OAuth for Team Members
+
+For individual developers on your team, prefer OAuth over shared API keys. Each user authenticates with their own identity, providing:
+
+- Accurate audit trails showing who did what
+- Per-user seat tracking
+- No shared credentials to manage or rotate
+
 ### Environment Segmentation
 
 Use separate API tokens for different environments:
@@ -87,13 +124,13 @@ Use separate API tokens for different environments:
 
 ### Token Rotation
 
-Regularly rotate API tokens and set expiration dates to limit exposure if a token is compromised.
+Regularly rotate API tokens and set expiration dates to limit exposure if a token is compromised. OAuth tokens are automatically rotated by the gateway.
 
 ## Audit & Compliance
 
 All MCP Server operations are logged in [Audit Logs](/articles/audit-logs):
 
-- API calls are attributed to the user or API token
+- API calls are attributed to the user (via OAuth) or API token
 - Logs include action type, timestamp, and affected resources
 - Audit logs can be exported for compliance reviews
 - Default retention: 180 days (configurable)
@@ -123,6 +160,7 @@ testkube mcp serve
 ## Additional Resources
 
 - [MCP Server Overview](/articles/mcp-overview)
+- [MCP Hosted Endpoint](/articles/mcp-hosted)
 - [API Token Management](/articles/api-token-management)
 - [Audit Logs](/articles/audit-logs)
 - [Environments & Access Control](/articles/environments-best-practices)


### PR DESCRIPTION
## Summary

Updates MCP documentation to cover the new OAuth authentication on the hosted MCP endpoint.

## Changes

- **mcp-hosted.md**: OAuth as recommended auth method, config examples for Claude Code and VS Code, API tokens reframed as alternative for automation, Dex callback registration step for self-hosted
- **mcp-security.md**: OAuth as third auth method, updated best practices (OAuth for individuals, API tokens for automation)
- **mcp-configuration.md**: OAuth-based config examples for VS Code, Claude Code, Claude Desktop
- **mcp-overview.md**: OAuth mention in hosted endpoint feature list