### PR TITLE
docs: [TKC-5856] add 2.9.6 and 2.9.7 changelog

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -8,6 +8,22 @@ This is the changelog for the Testkube Control Plane, latest releases are on top
 - **Doc updates** focus on major changes to the documentation
   :::
 
+## Patch Release v2.9.7 (2026-05-29)
+
+Control Plane is available in Helm chart `v2.332.7`.
+
+### Improvements
+
+- **PostgreSQL performance improvements**: Improved PostgreSQL query performance.
+
+## Patch Release v2.9.6 (2026-05-28)
+
+Control Plane is available in Helm chart `v2.332.6`.
+
+### Improvements
+
+- **PostgreSQL performance improvements**: Improved PostgreSQL query performance.
+
 ## Patch Release v2.9.5 (2026-05-15)
 
 Control Plane is available in Helm chart `v2.332.5` and the Agent is available in Helm chart `v2.9.5`.


### PR DESCRIPTION
## Summary
- add missing v2.9.6 and v2.9.7 changelog entries
- mention Control Plane chart versions only
- keep release note wording limited to PostgreSQL performance improvements

## Validation
- git diff --check
- npm run build

Linear: https://linear.app/kubeshop/issue/TKC-5856/finalize-us-cloud-297-release-tracking-and-changelog