### PR TITLE
docs: [TKC-5860] add templated security context changelog note

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -70,6 +70,10 @@ This release improves agent reliability for webhooks and execution-related flows
 
 ### Open Source Updates
 
+#### Templated Security Contexts
+
+TestWorkflowTemplates can now use integer config parameters in security context fields such as `runAsUser`, `runAsGroup`, and `fsGroup`. This lets reusable templates render valid Kubernetes pod and container security contexts while keeping those values configurable.
+
 #### AI Analysis in the Public Execution Viewer
 
 Sharing a workflow execution publicly is useful for debugging handoffs, but raw logs and reports still take time to interpret. The public execution viewer now includes AI-generated summaries of test results so readers can quickly understand failures and what to investigate next — alongside the JUnit report browsing added in recent patches.


### PR DESCRIPTION
## Summary
- add a v2.10.0 changelog note for templated integer config values in TestWorkflowTemplate security context fields
- mention `runAsUser`, `runAsGroup`, and `fsGroup` support

## Validation
- `npm run build`

Linear: https://linear.app/kubeshop/issue/TKC-5860/document-templated-security-context-support-in-changelog