### PR TITLE
docs(agents): document runner label & mode refresh on reconnect (TKC-5876)

### DIFF
--- a/docs/articles/agents-overview.md
+++ b/docs/articles/agents-overview.md
@@ -99,8 +99,8 @@ The table has the following columns:
 
 - **Name**:  The name given to the agent on creation.
 - **Capabilities**: Capability icons for the agent.
-- **Labels**: Labels reported by the Runner Agent — refreshed on every reconnect, see [Updating Runner Agent labels and mode](#updating-runner-agent-labels-and-mode) and [Using labels for Runner Agent selection](/articles/test-workflows-running#using-labels-for-runner-agent-selection).
-- **Runner Mode**: The Runner Mode of the agent if it is a Runner Agent — also refreshed on every reconnect, see [Updating Runner Agent labels and mode](#updating-runner-agent-labels-and-mode) and [Runner Agent modes](/articles/test-workflows-running#runner-agent-modes).
+- **Labels**: Labels currently associated with the Runner Agent. Can be set with `testkube update agent` or via the runner's Helm values — see [Updating Runner Agent labels and mode](#updating-runner-agent-labels-and-mode) and [Using labels for Runner Agent selection](/articles/test-workflows-running#using-labels-for-runner-agent-selection).
+- **Runner Mode**: The Runner Mode of the agent if it is a Runner Agent. Can be changed with `testkube update agent` or via the runner's Helm values — see [Updating Runner Agent labels and mode](#updating-runner-agent-labels-and-mode) and [Runner Agent modes](/articles/test-workflows-running#runner-agent-modes).
 - **License**: The type of license assigned to the Agent if it is a Runner Agent - [Read More](#licensing-for-runner-agents)
 - **Agent ID**: the Agent ID
 - **Version**: The version of the Agent; a warning triangle will be shown if an updated version is available.
@@ -154,40 +154,61 @@ When this toggle is enabled, the Testkube Dashboard will no longer display sensi
 
 ## Updating Runner Agent labels and mode
 
-A Runner Agent's labels and mode (`--global` / `--group`) are not frozen at creation time. Every time the
-Runner Agent reconnects to the Control Plane (for example after a pod restart, Helm upgrade, or rolling
-update of its Deployment), the runner re-publishes its current labels, runner group, and global flag, and
-the Control Plane updates its stored copy.
+A Runner Agent's labels and mode (`--global` / `--group`) can be managed in two ways, and both are
+supported simultaneously:
 
-This means you can change a runner's labels or mode by editing its Deployment / Helm values and restarting
-the pod — there is no need to delete and re-create the Agent in the Control Plane.
+1. **From the Control Plane** — using `testkube update agent <name> -l <key>=<value>` or the Dashboard.
+2. **From the runner Deployment** — by setting `runner.register.labels`, `runner.register.global`, or
+   `runner.register.groupName` in the Helm values (or the equivalent `RUNNER_LABELS_PREFIX`-prefixed
+   Deployment annotations and `RUNNER_GROUP` / `RUNNER_IS_GLOBAL` environment variables).
 
-**How the runner sources its metadata**
+When a runner restarts (for example after a Helm upgrade or rolling update of its Deployment) it
+reconnects to the Control Plane and may republish its registration metadata, but **only for the fields it
+is explicitly configured to manage**:
 
-| Field        | Source on the Runner                                                                                  |
-|--------------|-------------------------------------------------------------------------------------------------------|
-| Labels       | Annotations on the runner Deployment whose key starts with `runner.testkube.io/` (configurable via the `RUNNER_LABELS_PREFIX` env var, or the `runner.register.labelPrefix` Helm value). The `runner.register.labels` Helm value writes these annotations for you. |
-| Runner group | `RUNNER_GROUP` environment variable, set by the `runner.register.groupName` Helm value or the `--group` CLI flag.            |
-| Global flag  | `RUNNER_IS_GLOBAL` environment variable, set by the `runner.register.global` Helm value or the `--global` CLI flag.          |
+| Runner-side configuration                                  | What gets refreshed on reconnect                          |
+|------------------------------------------------------------|-----------------------------------------------------------|
+| At least one annotation under `runner.testkube.io/`        | Labels are replaced with the runner's set                 |
+| No matching annotations                                    | Labels are **preserved** (the runner does not touch them) |
+| `runner.register.global=true` or `runner.register.groupName` set | Runner mode is replaced with the runner's setting   |
+| Neither set (`Independent` defaults)                       | Runner mode is **preserved** (the runner does not touch it) |
+| Kubernetes API error reading the Deployment                | Labels are preserved (warning logged); mode follows the rules above |
 
-**Typical workflow**
+This means CLI-managed agents keep working unchanged after upgrade: if you have not configured labels or
+mode in your runner's Helm values, the runner will not overwrite values you set with
+`testkube update agent` or `testkube create agent --global` / `--group`.
 
-1. Update the runner's Helm values (or Deployment manifest) — for example, add a label under
-   `runner.register.labels` or set `runner.register.groupName=eu-runners`.
-2. Apply the change (`helm upgrade ...` or `kubectl apply`) so the runner pod restarts.
-3. On reconnect, the runner sends the new metadata to the Control Plane and the Agents list reflects it.
+### Switching to Helm as the source of truth
+
+If you want the runner Deployment itself to be the source of truth for labels and/or mode, set the
+corresponding Helm values and run `helm upgrade`:
+
+| Field        | Helm value                          | Runner env var          |
+|--------------|--------------------------------------|-------------------------|
+| Labels       | `runner.register.labels`             | (annotations under `RUNNER_LABELS_PREFIX`, default `runner.testkube.io/`) |
+| Runner group | `runner.register.groupName`          | `RUNNER_GROUP`          |
+| Global flag  | `runner.register.global`             | `RUNNER_IS_GLOBAL`      |
+
+Once the runner pod restarts and reconnects, the Agents list in the Dashboard will reflect the new values.
+From that point on, any change you make through the CLI will be **overwritten** the next time the runner
+reconnects — pick a single source of truth per runner.
+
+### Demoting a Global or Grouped runner to Independent
+
+Clearing `runner.register.global` / `runner.register.groupName` and reconnecting will **not** demote a
+runner to Independent: an empty policy snapshot is indistinguishable from "unset," so the runner does not
+touch the stored mode in that case (this prevents accidental downgrades during Helm value cleanups). To
+demote a runner explicitly, use:
+
+```sh
+$ testkube update agent <name> --runner-mode independent   # or use the Dashboard
+```
 
 :::note
-If the runner cannot read its labels at startup (for example a transient Kubernetes API error), it will
-still refresh the runner group and global flag, but it **will not** clear the previously stored labels.
-This prevents a momentary read failure from wiping label-based routing rules. The runner logs a warning
-in this case (`skipping label refresh; cannot read deployment labels`).
-:::
-
-:::tip
-If you only want to tweak labels from the CLI without restarting the runner, you can still use
-`testkube update agent <name> -l <key>=<value>` — see [Updating Runner Agent Labels](/articles/multi-agent-cli#updating-runner-agent-labels).
-The next time the runner reconnects, its own published labels will become the source of truth again.
+Upgrading from a release before this change ([kubeshop/testkube#7791](https://github.com/kubeshop/testkube/pull/7791))
+is safe for environments where labels and runner policy were managed via the CLI: those values are
+preserved on reconnect because the runner only refreshes fields it has been explicitly configured to
+publish.
 :::
 
 ## Agent Key Rotation

--- a/docs/articles/agents-overview.md
+++ b/docs/articles/agents-overview.md
@@ -159,20 +159,20 @@ supported simultaneously:
 
 1. **From the Control Plane** — using `testkube update agent <name> -l <key>=<value>` or the Dashboard.
 2. **From the runner Deployment** — by setting `runner.register.labels`, `runner.register.global`, or
-   `runner.register.groupName` in the Helm values (or the equivalent `RUNNER_LABELS_PREFIX`-prefixed
-   Deployment annotations and `RUNNER_GROUP` / `RUNNER_IS_GLOBAL` environment variables).
+   `runner.register.groupName` in the Helm values (or the equivalent `RUNNER_GROUP` / `RUNNER_IS_GLOBAL`
+   environment variables on the runner Deployment).
 
 When a runner restarts (for example after a Helm upgrade or rolling update of its Deployment) it
 reconnects to the Control Plane and may republish its registration metadata, but **only for the fields it
 is explicitly configured to manage**:
 
-| Runner-side configuration                                  | What gets refreshed on reconnect                          |
-|------------------------------------------------------------|-----------------------------------------------------------|
-| At least one annotation under `runner.testkube.io/`        | Labels are replaced with the runner's set                 |
-| No matching annotations                                    | Labels are **preserved** (the runner does not touch them) |
+| Runner-side configuration                                        | What gets refreshed on reconnect                          |
+|------------------------------------------------------------------|-----------------------------------------------------------|
+| At least one entry in `runner.register.labels`                   | Labels are replaced with the runner's set                 |
+| `runner.register.labels` is empty / unset                        | Labels are **preserved** (the runner does not touch them) |
 | `runner.register.global=true` or `runner.register.groupName` set | Runner mode is replaced with the runner's setting   |
-| Neither set (`Independent` defaults)                       | Runner mode is **preserved** (the runner does not touch it) |
-| Kubernetes API error reading the Deployment                | Labels are preserved (warning logged); mode follows the rules above |
+| Neither set (`Independent` defaults)                             | Runner mode is **preserved** (the runner does not touch it) |
+| Kubernetes API error reading the Deployment                      | Labels are preserved (warning logged); mode follows the rules above |
 
 This means CLI-managed agents keep working unchanged after upgrade: if you have not configured labels or
 mode in your runner's Helm values, the runner will not overwrite values you set with
@@ -185,7 +185,7 @@ corresponding Helm values and run `helm upgrade`:
 
 | Field        | Helm value                          | Runner env var          |
 |--------------|--------------------------------------|-------------------------|
-| Labels       | `runner.register.labels`             | (annotations under `RUNNER_LABELS_PREFIX`, default `runner.testkube.io/`) |
+| Labels       | `runner.register.labels`             | (label key prefix configurable via `RUNNER_LABELS_PREFIX`, default `runner.testkube.io/`) |
 | Runner group | `runner.register.groupName`          | `RUNNER_GROUP`          |
 | Global flag  | `runner.register.global`             | `RUNNER_IS_GLOBAL`      |
 

--- a/docs/articles/agents-overview.md
+++ b/docs/articles/agents-overview.md
@@ -99,8 +99,8 @@ The table has the following columns:
 
 - **Name**:  The name given to the agent on creation.
 - **Capabilities**: Capability icons for the agent.
-- **Labels**: Labels assigned to the Runner Agents on creation - [Read More](/articles/test-workflows-running#using-labels-for-runner-agent-selection)
-- **Runner Mode**: The Runner Mode of the agent if it is a Runner Agent - [Read More](/articles/test-workflows-running#runner-agent-modes)
+- **Labels**: Labels reported by the Runner Agent — refreshed on every reconnect, see [Updating Runner Agent labels and mode](#updating-runner-agent-labels-and-mode) and [Using labels for Runner Agent selection](/articles/test-workflows-running#using-labels-for-runner-agent-selection).
+- **Runner Mode**: The Runner Mode of the agent if it is a Runner Agent — also refreshed on every reconnect, see [Updating Runner Agent labels and mode](#updating-runner-agent-labels-and-mode) and [Runner Agent modes](/articles/test-workflows-running#runner-agent-modes).
 - **License**: The type of license assigned to the Agent if it is a Runner Agent - [Read More](#licensing-for-runner-agents)
 - **Agent ID**: the Agent ID
 - **Version**: The version of the Agent; a warning triangle will be shown if an updated version is available.
@@ -150,6 +150,44 @@ When this toggle is enabled, the Testkube Dashboard will no longer display sensi
 
 :::warning
 **Important:** This masking feature applies **only** to the Testkube Dashboard UI. Agent tokens or secret keys will still be visible in CLI outputs (e.g., when using `testkube create runner` or retrieving details for Helm chart installation as described in [Installing Runner Agent with Helm Charts](/articles/multi-agent-runner-helm-chart)) and in any direct API interactions.
+:::
+
+## Updating Runner Agent labels and mode
+
+A Runner Agent's labels and mode (`--global` / `--group`) are not frozen at creation time. Every time the
+Runner Agent reconnects to the Control Plane (for example after a pod restart, Helm upgrade, or rolling
+update of its Deployment), the runner re-publishes its current labels, runner group, and global flag, and
+the Control Plane updates its stored copy.
+
+This means you can change a runner's labels or mode by editing its Deployment / Helm values and restarting
+the pod — there is no need to delete and re-create the Agent in the Control Plane.
+
+**How the runner sources its metadata**
+
+| Field        | Source on the Runner                                                                                  |
+|--------------|-------------------------------------------------------------------------------------------------------|
+| Labels       | Annotations on the runner Deployment whose key starts with `runner.testkube.io/` (configurable via the `RUNNER_LABELS_PREFIX` env var, or the `runner.register.labelPrefix` Helm value). The `runner.register.labels` Helm value writes these annotations for you. |
+| Runner group | `RUNNER_GROUP` environment variable, set by the `runner.register.groupName` Helm value or the `--group` CLI flag.            |
+| Global flag  | `RUNNER_IS_GLOBAL` environment variable, set by the `runner.register.global` Helm value or the `--global` CLI flag.          |
+
+**Typical workflow**
+
+1. Update the runner's Helm values (or Deployment manifest) — for example, add a label under
+   `runner.register.labels` or set `runner.register.groupName=eu-runners`.
+2. Apply the change (`helm upgrade ...` or `kubectl apply`) so the runner pod restarts.
+3. On reconnect, the runner sends the new metadata to the Control Plane and the Agents list reflects it.
+
+:::note
+If the runner cannot read its labels at startup (for example a transient Kubernetes API error), it will
+still refresh the runner group and global flag, but it **will not** clear the previously stored labels.
+This prevents a momentary read failure from wiping label-based routing rules. The runner logs a warning
+in this case (`skipping label refresh; cannot read deployment labels`).
+:::
+
+:::tip
+If you only want to tweak labels from the CLI without restarting the runner, you can still use
+`testkube update agent <name> -l <key>=<value>` — see [Updating Runner Agent Labels](/articles/multi-agent-cli#updating-runner-agent-labels).
+The next time the runner reconnects, its own published labels will become the source of truth again.
 :::
 
 ## Agent Key Rotation

--- a/docs/articles/multi-agent-cli.md
+++ b/docs/articles/multi-agent-cli.md
@@ -210,10 +210,12 @@ $ testkube update agent my-runner -L myReadiness      # delete label
 ```
 
 :::note
-Labels and runner mode (`--global` / `--group`) are also republished by the runner itself on every
-reconnect to the Control Plane, sourced from its Deployment annotations and environment variables. If you
-manage your runners through Helm, the recommended way to change labels or mode is to update the Helm
-values and restart the runner — see [Updating Runner Agent labels and mode](/articles/agents-overview#updating-runner-agent-labels-and-mode).
+Labels and runner mode (`--global` / `--group`) can also be managed from the runner Deployment by setting
+`runner.register.labels` / `runner.register.global` / `runner.register.groupName` in the Helm values. When
+those values are set, the runner becomes the source of truth for the corresponding fields and will
+overwrite CLI changes on its next reconnect. When they are **not** set, CLI updates persist across runner
+restarts. See [Updating Runner Agent labels and mode](/articles/agents-overview#updating-runner-agent-labels-and-mode)
+for the full behavior.
 :::
 
 :::tip

--- a/docs/articles/multi-agent-cli.md
+++ b/docs/articles/multi-agent-cli.md
@@ -209,6 +209,13 @@ $ testkube update agent my-runner -l myReadiness=true # add label
 $ testkube update agent my-runner -L myReadiness      # delete label
 ```
 
+:::note
+Labels and runner mode (`--global` / `--group`) are also republished by the runner itself on every
+reconnect to the Control Plane, sourced from its Deployment annotations and environment variables. If you
+manage your runners through Helm, the recommended way to change labels or mode is to update the Helm
+values and restart the runner — see [Updating Runner Agent labels and mode](/articles/agents-overview#updating-runner-agent-labels-and-mode).
+:::
+
 :::tip
 Check out [Using labels for filtering runners](/articles/test-workflows-running#using-labels-for-runner-agent-selection) to see examples
 for how to use labels for selecting Runner Agents for Workflow execution.

--- a/docs/articles/multi-agent-runner-helm-chart.md
+++ b/docs/articles/multi-agent-runner-helm-chart.md
@@ -64,8 +64,9 @@ cloud:
 
 ## Updating runner labels and mode
 
-A Runner Agent's labels and mode are republished to the Control Plane every time the runner reconnects.
-To change them, update the corresponding Helm values and run `helm upgrade` so the runner pod restarts:
+If you want the runner Deployment itself to be the source of truth for labels and runner mode (instead of
+managing them through `testkube update agent`), set the corresponding Helm values and run `helm upgrade`
+so the runner pod restarts:
 
 | Helm value                    | Purpose                                                              |
 |-------------------------------|----------------------------------------------------------------------|
@@ -84,9 +85,15 @@ helm upgrade --install \
   my-runner oci://us-east1-docker.pkg.dev/testkube-cloud-372110/testkube/testkube-runner --version <version>
 ```
 
-The Agents list in the Dashboard will reflect the new labels and runner mode once the runner reconnects.
-See [Updating Runner Agent labels and mode](/articles/agents-overview#updating-runner-agent-labels-and-mode)
-for details, including the failure-mode behavior when label collection fails at startup.
+Once the runner reconnects, the Agents list in the Dashboard will reflect the new values. From that point
+on, any change made through `testkube update agent` for those fields will be overwritten on the runner's
+next reconnect — pick a single source of truth per runner.
+
+If `runner.register.labels` / `runner.register.global` / `runner.register.groupName` are **not** set,
+the runner will not touch the corresponding stored values on reconnect, so existing CLI-managed agents
+remain unchanged after a Helm upgrade. See
+[Updating Runner Agent labels and mode](/articles/agents-overview#updating-runner-agent-labels-and-mode)
+for the complete behavior matrix.
 
 ## Self-registering Agent Helm install
 

--- a/docs/articles/multi-agent-runner-helm-chart.md
+++ b/docs/articles/multi-agent-runner-helm-chart.md
@@ -72,7 +72,7 @@ so the runner pod restarts:
 |-------------------------------|----------------------------------------------------------------------|
 | `runner.register.global`      | Register the runner as a [Global Runner Agent](/articles/test-workflows-running#global-runner-agents). |
 | `runner.register.groupName`   | Register the runner as a [Grouped Runner Agent](/articles/test-workflows-running#grouped-runner-agents) (cannot be combined with `runner.register.global`). |
-| `runner.register.labels`      | Map of labels to publish to the Control Plane. Rendered onto the runner Deployment as annotations using `runner.register.labelPrefix` (default `runner.testkube.io/`). |
+| `runner.register.labels`      | Map of labels to publish to the Control Plane. Each key is published with `runner.register.labelPrefix` (default `runner.testkube.io/`) prepended. |
 
 Example:
 

--- a/docs/articles/multi-agent-runner-helm-chart.md
+++ b/docs/articles/multi-agent-runner-helm-chart.md
@@ -62,6 +62,32 @@ cloud:
   url: "agent.testkube.io:443"
 ```
 
+## Updating runner labels and mode
+
+A Runner Agent's labels and mode are republished to the Control Plane every time the runner reconnects.
+To change them, update the corresponding Helm values and run `helm upgrade` so the runner pod restarts:
+
+| Helm value                    | Purpose                                                              |
+|-------------------------------|----------------------------------------------------------------------|
+| `runner.register.global`      | Register the runner as a [Global Runner Agent](/articles/test-workflows-running#global-runner-agents). |
+| `runner.register.groupName`   | Register the runner as a [Grouped Runner Agent](/articles/test-workflows-running#grouped-runner-agents) (cannot be combined with `runner.register.global`). |
+| `runner.register.labels`      | Map of labels to publish to the Control Plane. Rendered onto the runner Deployment as annotations using `runner.register.labelPrefix` (default `runner.testkube.io/`). |
+
+Example:
+
+```sh
+helm upgrade --install \
+  --namespace my-runner \
+  --reuse-values \
+  --set 'runner.register.groupName=eu-runners' \
+  --set 'runner.register.labels.region=europe' \
+  my-runner oci://us-east1-docker.pkg.dev/testkube-cloud-372110/testkube/testkube-runner --version <version>
+```
+
+The Agents list in the Dashboard will reflect the new labels and runner mode once the runner reconnects.
+See [Updating Runner Agent labels and mode](/articles/agents-overview#updating-runner-agent-labels-and-mode)
+for details, including the failure-mode behavior when label collection fails at startup.
+
 ## Self-registering Agent Helm install
 
 Sometimes it may be desirable to allow Agents to create themselves automatically on deployment (without using the CLI),

--- a/docs/articles/test-workflows-running.mdx
+++ b/docs/articles/test-workflows-running.mdx
@@ -89,10 +89,11 @@ Runner Agents can be created in one of three different modes, impacting how they
 - **Global Runner Agents** do not need to be targeted by name but can be filtered by labels, the default Standalone Agent works as a Global Runner Agent.
 
 :::note
-A Runner Agent's mode (`--global` / `--group`) is not frozen at creation time — it is republished by the
-runner every time it reconnects to the Control Plane. To change the mode, update the corresponding Helm
-value or CLI flag on the runner Deployment and restart it; the new mode will take effect on reconnect.
-See [Updating Runner Agent labels and mode](/articles/agents-overview#updating-runner-agent-labels-and-mode).
+A Runner Agent's mode (`--global` / `--group`) can be changed in two ways: with `testkube update agent` /
+the Dashboard, or by setting `runner.register.global` / `runner.register.groupName` in the runner's Helm
+values and restarting the pod. Demoting a Global or Grouped runner back to Independent must be done via
+the CLI — clearing the Helm value alone will not demote it. See
+[Updating Runner Agent labels and mode](/articles/agents-overview#updating-runner-agent-labels-and-mode).
 :::
 
 ### Independent Runner Agents
@@ -173,9 +174,10 @@ Workflow via the CLI or Dashboard, or at design-time when defining Workflows, Cr
 Labels can be added to any type of Runner Agent with the `-l <name=value>` argument during creation, these
 can then be used to filter out Runner Agents that are used for execution.
 
-Labels are also republished by the runner on every reconnect, so updating the runner Deployment (or Helm
-values) and restarting the pod is enough to change the label set used for routing — see
-[Updating Runner Agent labels and mode](/articles/agents-overview#updating-runner-agent-labels-and-mode).
+Labels can be updated either with `testkube update agent <name> -l <key>=<value>` or by setting
+`runner.register.labels` in the runner's Helm values — see
+[Updating Runner Agent labels and mode](/articles/agents-overview#updating-runner-agent-labels-and-mode)
+for when each method takes effect.
 
 
 ```sh

--- a/docs/articles/test-workflows-running.mdx
+++ b/docs/articles/test-workflows-running.mdx
@@ -89,7 +89,10 @@ Runner Agents can be created in one of three different modes, impacting how they
 - **Global Runner Agents** do not need to be targeted by name but can be filtered by labels, the default Standalone Agent works as a Global Runner Agent.
 
 :::note
-If you need to change the type of Runner Agent, you'll need to remove it first and re-add with the new type.
+A Runner Agent's mode (`--global` / `--group`) is not frozen at creation time — it is republished by the
+runner every time it reconnects to the Control Plane. To change the mode, update the corresponding Helm
+value or CLI flag on the runner Deployment and restart it; the new mode will take effect on reconnect.
+See [Updating Runner Agent labels and mode](/articles/agents-overview#updating-runner-agent-labels-and-mode).
 :::
 
 ### Independent Runner Agents
@@ -168,7 +171,12 @@ Workflow via the CLI or Dashboard, or at design-time when defining Workflows, Cr
 ### Using labels for Runner Agent selection
 
 Labels can be added to any type of Runner Agent with the `-l <name=value>` argument during creation, these
-can then be used to filter out Runner Agents that are used for execution:
+can then be used to filter out Runner Agents that are used for execution.
+
+Labels are also republished by the runner on every reconnect, so updating the runner Deployment (or Helm
+values) and restarting the pod is enough to change the label set used for routing — see
+[Updating Runner Agent labels and mode](/articles/agents-overview#updating-runner-agent-labels-and-mode).
+
 
 ```sh
 # run Workflow on a Runner Agent in the staging-runners group with the region=europe label


### PR DESCRIPTION
Linear: [TKC-5876](https://linear.app/testkube/issue/TKC-5876)
Pairs with: kubeshop/testkube#7786 (merged) and kubeshop/testkube-cloud-api#3961 (merged).

## Why

After TKC-5876, Runner Agents republish their labels, runner group, and global flag to the Control Plane **on every reconnect**, not only at first registration. The proto carries two independent flags (`update_labels`, `update_runner_policy`) so a transient label-read failure on the runner cannot wipe previously-stored labels.

The existing docs still imply that labels and runner mode are frozen at agent creation \u2014 most notably:

- `agents-overview.md` says `Labels: Labels assigned to the Runner Agents on creation`.
- `test-workflows-running.mdx` carries the admonition `If you need to change the type of Runner Agent, you'll need to remove it first and re-add with the new type.` which is no longer correct.

## What

- **`agents-overview.md`** \u2014 new section `Updating Runner Agent labels and mode` (single source of truth: env-var/Helm-value mapping, typical workflow, and the failure-mode behavior where the runner preserves previously-stored labels if it cannot read its Deployment annotations). Fixes the misleading line in the Agents table.
- **`test-workflows-running.mdx`** \u2014 replaces the `remove first / re-add` admonition with a pointer to the new section; adds a short paragraph in 'Using labels for Runner Agent selection' explaining label updates propagate on reconnect.
- **`multi-agent-cli.md`** \u2014 cross-link from 'Updating Runner Agent Labels' to the new section so CLI users discover the Helm-driven workflow.
- **`multi-agent-runner-helm-chart.md`** \u2014 new 'Updating runner labels and mode' section with the **correct** Helm keys (`runner.register.global`, `runner.register.groupName`, `runner.register.labels`) and a `helm upgrade --reuse-values` example.

## Verification

- All four files lint as Markdown/MDX (no broken admonitions).
- Anchor link `#updating-runner-agent-labels-and-mode` matches the new heading in `agents-overview.md` and is referenced from the three other files.
- Helm key paths cross-checked against `testkube/k8s/helm/testkube-runner/values.yaml` (`runner.register.{global,groupName,labels,labelPrefix}`) and the env vars in `testkube/internal/config/config.go` (`RUNNER_IS_GLOBAL`, `RUNNER_GROUP`, `RUNNER_LABELS_PREFIX`).
