### PR TITLE
feat(docs): document private CA trust for MCP bridge and connected MCP servers

### DIFF
--- a/docs/articles/mcp-hosted.md
+++ b/docs/articles/mcp-hosted.md
@@ -180,6 +180,10 @@ After deploying with MCP enabled, you need to enable it for each environment:
 
 For self-hosted instances, use your custom control plane URL:
 
+If your control plane or connected MCP integrations rely on certificates signed
+by a private CA, configure trust using
+[Using a private certificate authority (CA)](/articles/private-ca).
+
 **With OAuth (recommended):**
 
 ```json

--- a/docs/articles/mcp-servers-for-ai-agents.mdx
+++ b/docs/articles/mcp-servers-for-ai-agents.mdx
@@ -40,6 +40,12 @@ The modal prompts you for:
 If the provided MCP Server can be accessed successfully, it will be added to the list of MCP Servers for further
 configuration (see below).
 
+:::tip Private CA / self-signed certificates
+For self-hosted deployments, if your MCP Server uses a certificate signed by a
+private CA, configure private CA trust using the
+[Using a private certificate authority (CA)](/articles/private-ca) guide.
+:::
+
 ## Authentication
 
 Testkube supports two methods for authenticating with MCP Servers:

--- a/docs/articles/private-ca.md
+++ b/docs/articles/private-ca.md
@@ -121,3 +121,22 @@ However, if the containers specified as part of the workflow require the trust
 of your private CA then you will need to configure the container/pod in a
 similar way as shown in the global template to mount the CA bundle to the right
 location and/or, if necessary, specify an environment variable.
+
+## AI Agents and Connected MCP Servers
+
+If your AI Agents use Connected MCP Servers with certificates signed by a
+private CA (for example self-hosted MCP servers), setting
+`global.customCaSecretRef` and `global.customCaSecretKey` in the
+`testkube-enterprise` chart is also used for outbound MCP bridge connections in
+the AI service.
+
+With this configuration in place, Testkube forwards CA-related trust settings
+to the MCP bridge process, so requests to those MCP servers can validate
+private-CA certificates correctly.
+
+If you still see `certificate signed by unknown authority`, verify that:
+
+- the mounted CA bundle contains the full required chain,
+- `customCaSecretRef` points to the correct secret in the release namespace,
+- the key configured in `customCaSecretKey` matches the secret key containing
+  the CA bundle.


### PR DESCRIPTION
## Summary
- add a new section in `private-ca.md` documenting private-CA behavior for AI Agents and Connected MCP Servers
- add a discoverability tip in `mcp-servers-for-ai-agents.mdx` linking to private CA setup
- add a self-hosted note in `mcp-hosted.md` linking to private CA setup

## Why
Customers using self-signed/private-CA certificates with Connected MCP Servers need clear guidance that global private CA configuration applies to MCP bridge outbound connections used by AI service.

## Included docs updates
- canonical guidance: `docs/articles/private-ca.md`
- entry-point cross-link: `docs/articles/mcp-servers-for-ai-agents.mdx`
- self-hosted MCP endpoint cross-link: `docs/articles/mcp-hosted.md`