### PR TITLE
chore: release 2.10.3 changelog

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -8,6 +8,12 @@ This is the changelog for the Testkube Control Plane, latest releases are on top
 - **Doc updates** focus on major changes to the documentation
   :::
 
+## Patch Release v2.10.3 (2026-06-09)
+
+Control Plane is available in Helm chart `v2.333.3`.
+
+Incremental adjustments with no impact on enterprise/on-premise deployments.
+
 ## Patch Release v2.10.2 (2026-06-07)
 
 Control Plane is available in Helm chart `v2.333.2` and the Agent is available in Helm chart `v2.10.1`.


### PR DESCRIPTION
Adds a changelog entry for the v2.10.3 patch release (tag `2.10.3`, Helm chart `v2.333.3`).

Kept the entry generic per discussion with @javier — internal-only changes with no impact on enterprise/on-premise deployments.

## Note on missing v2.10.1 entry

`v2.10.1` doesn't have a changelog entry between `v2.10.0` and `v2.10.2`. Out of scope for this PR, just flagging in case someone wants to backfill.