### PR TITLE
docs: Add AI Testing section to Examples & Guides

### DIFF
--- a/docs/articles/examples/deepeval-basic.mdx
+++ b/docs/articles/examples/deepeval-basic.mdx
@@ -1,0 +1,27 @@
+import ParallelDeepEval from "../../workflows/parallel-deepeval-workflow.md"
+
+# DeepEval Example - Comparing Models in Parallel
+
+[DeepEval](https://deepeval.com/) is an open-source LLM evaluation framework that integrates with pytest,
+making it a natural fit for treating LLM evaluations as regular tests. The Workflow below runs the same
+DeepEval test suite against three different OpenAI models in parallel using a
+[matrix](/articles/test-workflows-matrix-and-sharding), and ingests the generated JUnit reports so each
+model's results show up as structured test results in Testkube.
+You can paste this directly into the YAML of an existing or new Workflow, just make sure to update the
+`name` and `namespace` for your environment if needed.
+
+- The `spec.content` property checks out the DeepEval test suite from GitHub.
+- The `spec.container` property defines the working directory, Python image, and environment variables for the
+  Workflow; the `OPENAI_API_KEY` is resolved using the [credential](/articles/credential-management) expression
+  so the key is never stored in the Workflow definition itself.
+- The **"Run tests"** step uses `parallel.matrix` to fan out three executions - one per model - each with the
+  `OPENAI_MODEL_NAME` environment variable set to the corresponding matrix value.
+- Each parallel execution installs DeepEval, runs the test suite, and uploads the generated JUnit XML report
+  as an artifact, which Testkube automatically picks up as test results.
+- The `job.activeDeadlineSeconds` property puts an upper bound on the total execution time.
+
+<ParallelDeepEval/>
+
+After execution, each parallel run is shown separately in the execution view with its own log output, and the
+JUnit reports give a per-model breakdown of which evaluations passed or failed - making it easy to compare
+how different models perform against the same quality criteria.

--- a/docs/articles/examples/inspect-ai-basic.mdx
+++ b/docs/articles/examples/inspect-ai-basic.mdx
@@ -1,0 +1,25 @@
+import SimpleInspectAi from "../../workflows/simple-inspect-ai-workflow.md"
+
+# Basic Inspect AI Example
+
+[Inspect AI](https://inspect.aisi.org.uk/) is an open-source framework from the UK AI Safety Institute for
+evaluating large language models. The Workflow below defines a small inline evaluation task, runs it against
+an OpenAI model, and applies a quality gate that fails the Workflow if accuracy drops below a threshold.
+You can paste this directly into the YAML of an existing or new Workflow, just make sure to update the
+`name` and `namespace` for your environment if needed.
+
+- The `spec.content.files` property defines two inline files:
+  - `task.py` - an Inspect AI task with three samples that are scored with the `includes()` scorer.
+  - `gate.py` - a quality gate script that parses the Inspect log and fails the run if accuracy is below `0.5`.
+- The `spec.container` property defines the working directory, Python image, and environment variables for the
+  Workflow; the `OPENAI_API_KEY` is resolved using the [credential](/articles/credential-management) expression
+  so the key is never stored in the Workflow definition itself.
+- The **"Install, eval and gate"** step installs Inspect AI, runs the evaluation, and applies the quality gate -
+  turning a model evaluation into a pass/fail test result.
+- The **"Save logs"** step uploads the Inspect JSON logs as artifacts; the `always` condition makes sure the logs
+  are uploaded even if the evaluation or quality gate fails.
+
+<SimpleInspectAi/>
+
+After execution, the evaluation output and quality-gate result are shown in the Log Output tab, and the
+Inspect JSON logs are available under the Artifacts tab of the execution.

--- a/docs/articles/examples/lm-eval-basic.mdx
+++ b/docs/articles/examples/lm-eval-basic.mdx
@@ -1,0 +1,23 @@
+import SimpleLmEval from "../../workflows/simple-lm-eval-workflow.md"
+
+# Basic LM Evaluation Harness Example
+
+The [LM Evaluation Harness](https://github.com/EleutherAI/lm-evaluation-harness) from EleutherAI is the
+de-facto standard for benchmarking language models against academic tasks (it powers the Open LLM Leaderboard).
+The Workflow below runs a small slice of the `gsm8k` math benchmark against an OpenAI model through the
+harness's API model interface and uploads the results as artifacts.
+You can paste this directly into the YAML of an existing or new Workflow, just make sure to update the
+`name` and `namespace` for your environment if needed.
+
+- The `spec.container` property defines the working directory, Python image, and environment variables for the
+  Workflow; the `OPENAI_API_KEY` is resolved using the [credential](/articles/credential-management) expression
+  so the key is never stored in the Workflow definition itself.
+- The **"Install and run lm-eval"** step installs the harness with API support and runs the `gsm8k` task,
+  limited to 5 samples to keep the example fast and inexpensive - remove the `--limit` flag for a full benchmark run.
+- The **"Save results"** step uploads the JSON result files as artifacts; the `always` condition makes sure the
+  results are uploaded even if the benchmark fails.
+
+<SimpleLmEval/>
+
+After execution, the benchmark scores are shown in the Log Output tab, and the result files are available
+under the Artifacts tab of the execution.

--- a/docs/articles/examples/overview.mdx
+++ b/docs/articles/examples/overview.mdx
@@ -73,6 +73,16 @@ Frameworks for unit tests, integration tests, and BDD:
 - [TestContainers](test-containers-basic) - Shows how to configure a Workflow that uses TestContainers for container dependencies.
 - [Cucumber](https://testkube.io/learn/simplify-bdd-testing-for-distributed-java-applications-with-testkube) - Simplify BDD Testing for Distributed Java Applications (external)
 
+## AI Testing
+
+Tools for evaluating LLMs, prompts, and RAG pipelines:
+
+- [Promptfoo](promptfoo-basic) - Shows how to run a Promptfoo evaluation and collect its JSON/HTML reports.
+- [DeepEval](deepeval-basic) - Shows how to run a DeepEval test suite against multiple models in parallel with JUnit reporting.
+- [Inspect AI](inspect-ai-basic) - Shows how to run an Inspect AI evaluation with an accuracy quality gate.
+- [Ragas](ragas-basic) - Shows how to evaluate a RAG pipeline with faithfulness and relevancy metrics.
+- [LM Evaluation Harness](lm-eval-basic) - Shows how to run an academic benchmark (gsm8k) against an OpenAI model.
+
 ## Infrastructure Testing
 
 Tools for validating Kubernetes clusters and infrastructure:

--- a/docs/articles/examples/promptfoo-basic.mdx
+++ b/docs/articles/examples/promptfoo-basic.mdx
@@ -1,0 +1,23 @@
+import SimplePromptfoo from "../../workflows/simple-promptfoo-workflow.md"
+
+# Basic Promptfoo Example
+
+[Promptfoo](https://www.promptfoo.dev/) is a popular open-source tool for evaluating and red-teaming LLM
+applications using declarative test cases. The Workflow below runs the official Promptfoo
+[getting-started example](https://github.com/promptfoo/promptfoo/tree/main/examples/getting-started)
+and uploads the generated reports as artifacts.
+You can paste this directly into the YAML of an existing or new Workflow, just make sure to update the
+`name` and `namespace` for your environment if needed.
+
+- The `spec.content` property checks out the getting-started example from the Promptfoo GitHub repository.
+- The `spec.container` property defines the working directory, Node.js image, and environment variables for the Workflow;
+  the `OPENAI_API_KEY` is resolved using the [credential](/articles/credential-management) expression so the key
+  is never stored in the Workflow definition itself.
+- The **"Run promptfoo eval"** step runs the evaluation and writes both JSON and HTML reports.
+- The **"Save report"** step uploads the reports as artifacts; the `always` condition makes sure the reports
+  are uploaded even if the evaluation fails.
+
+<SimplePromptfoo/>
+
+After execution, the JSON and HTML reports are available under the Artifacts tab of the execution,
+and the evaluation output is shown in the Log Output tab.

--- a/docs/articles/examples/ragas-basic.mdx
+++ b/docs/articles/examples/ragas-basic.mdx
@@ -1,0 +1,24 @@
+import SimpleRagas from "../../workflows/simple-ragas-workflow.md"
+
+# Basic Ragas Example
+
+[Ragas](https://docs.ragas.io/) is an open-source framework for evaluating Retrieval-Augmented Generation (RAG)
+pipelines using metrics like faithfulness and response relevancy. The Workflow below evaluates a small inline
+dataset of question/answer/context samples and uploads the results as an artifact.
+You can paste this directly into the YAML of an existing or new Workflow, just make sure to update the
+`name` and `namespace` for your environment if needed.
+
+- The `spec.content.files` property defines an inline `ragas_eval.py` script that builds a two-sample evaluation
+  dataset and scores it with the `Faithfulness` and `ResponseRelevancy` metrics, using OpenAI for both the
+  judge LLM and embeddings.
+- The `spec.container` property defines the working directory, Python image, and environment variables for the
+  Workflow; the `OPENAI_API_KEY` is resolved using the [credential](/articles/credential-management) expression
+  so the key is never stored in the Workflow definition itself.
+- The **"Install and run Ragas"** step installs Ragas and its LangChain dependencies and runs the evaluation.
+- The **"Save results"** step uploads the JSON results as an artifact; the `always` condition makes sure the
+  results are uploaded even if the evaluation fails.
+
+<SimpleRagas/>
+
+After execution, the metric scores are shown in the Log Output tab, and the `ragas_results.json` file is
+available under the Artifacts tab of the execution.

--- a/docs/workflows/parallel-deepeval-workflow.md
+++ b/docs/workflows/parallel-deepeval-workflow.md
@@ -1,0 +1,47 @@
+```yaml showLineNumbers title="Parallel DeepEval Workflow"
+kind: TestWorkflow
+apiVersion: testworkflows.testkube.io/v1
+metadata:
+  name: deepeval-junit-reporter-test
+  namespace: testkube
+  labels:
+    type: ai
+spec:
+  content:
+    git:
+      uri: https://github.com/olensmar/deepeval-junit-reporter
+  container:
+    workingDir: /data/repo
+    image: python:3.12.6-alpine3.20
+    env:
+      - name: OPENAI_API_KEY
+        value: '{{credential("OPENAI_API_KEY")}}'
+    resources:
+      requests:
+        cpu: 256m
+        memory: 256Mi
+  job:
+    activeDeadlineSeconds: 180
+  steps:
+    - name: Run tests
+      parallel:
+        matrix:
+          model:
+            - gpt-4o
+            - gpt-5
+            - gpt-5.2
+        description: "Model: {{matrix.model}}"
+        transfer:
+          - from: /data/repo
+        container:
+          env:
+            - name: OPENAI_MODEL_NAME
+              value: "{{matrix.model}}"
+        shell: |
+          pip install --upgrade pip
+          pip install -U deepeval
+          deepeval test run test_junitreport.py
+        artifacts:
+          paths:
+            - test_reports/*.xml
+```

--- a/docs/workflows/simple-inspect-ai-workflow.md
+++ b/docs/workflows/simple-inspect-ai-workflow.md
@@ -1,0 +1,84 @@
+```yaml showLineNumbers title="Basic Inspect AI Workflow"
+kind: TestWorkflow
+apiVersion: testworkflows.testkube.io/v1
+metadata:
+  name: inspect-ai-getting-started
+  namespace: testkube
+  labels:
+    type: ai
+spec:
+  content:
+    files:
+      - path: /data/task.py
+        content: |
+          from inspect_ai import Task, task
+          from inspect_ai.dataset import Sample
+          from inspect_ai.scorer import includes
+          from inspect_ai.solver import generate
+
+          @task
+          def capitals():
+              return Task(
+                  dataset=[
+                      Sample(input="What is the capital of France? Reply with only the city name.", target="Paris"),
+                      Sample(input="What is the capital of Japan? Reply with only the city name.", target="Tokyo"),
+                      Sample(input="What is the capital of Sweden? Reply with only the city name.", target="Stockholm"),
+                  ],
+                  solver=generate(),
+                  scorer=includes(),
+              )
+      - path: /data/gate.py
+        content: |
+          import glob, json, sys
+
+          THRESHOLD = 0.5   # fail the workflow below this accuracy
+
+          files = sorted(glob.glob("logs/*.json"))
+          if not files:
+              print("No Inspect log found"); sys.exit(1)
+          data = json.load(open(files[-1]))
+
+          def find_accuracy(o):
+              out = []
+              if isinstance(o, dict):
+                  for k, v in o.items():
+                      if k == "accuracy" and isinstance(v, dict) and "value" in v:
+                          out.append(v["value"])
+                      else:
+                          out += find_accuracy(v)
+              elif isinstance(o, list):
+                  for x in o:
+                      out += find_accuracy(x)
+              return out
+
+          accs = find_accuracy(data)
+          acc = accs[0] if accs else None
+          print(f"accuracy={acc} threshold={THRESHOLD}")
+          if acc is None or acc < THRESHOLD:
+              print("Quality gate FAILED"); sys.exit(1)
+          print("Quality gate PASSED")
+  container:
+    workingDir: /data
+    image: python:3.12-slim
+    env:
+      - name: HOME
+        value: /data
+      - name: OPENAI_API_KEY
+        value: '{{credential("OPENAI_API_KEY")}}'
+    resources:
+      requests:
+        cpu: 500m
+        memory: 1Gi
+  steps:
+    - name: Install, eval and gate
+      shell: |
+        set -e
+        pip install --no-cache-dir inspect-ai openai
+        inspect eval task.py --model openai/gpt-5.4-mini --log-dir ./logs --log-format json
+        python gate.py
+    - name: Save logs
+      condition: always
+      artifacts:
+        paths:
+          - logs/*.json
+```

--- a/docs/workflows/simple-lm-eval-workflow.md
+++ b/docs/workflows/simple-lm-eval-workflow.md
@@ -1,0 +1,43 @@
+```yaml showLineNumbers title="Basic LM Evaluation Harness Workflow"
+kind: TestWorkflow
+apiVersion: testworkflows.testkube.io/v1
+metadata:
+  name: lm-eval-harness-getting-started
+  namespace: testkube
+  labels:
+    type: ai
+spec:
+  container:
+    workingDir: /data
+    image: python:3.12-slim
+    env:
+      - name: HOME
+        value: /data
+      - name: HF_HOME
+        value: /data/hf
+      - name: HF_HUB_DISABLE_TELEMETRY
+        value: "1"
+      - name: OPENAI_API_KEY
+        value: '{{credential("OPENAI_API_KEY")}}'
+    resources:
+      requests:
+        cpu: "1"
+        memory: 2Gi
+  steps:
+    - name: Install and run lm-eval
+      shell: |
+        set -e
+        pip install --no-cache-dir "lm-eval[api]"
+        lm_eval --model local-chat-completions \
+          --model_args model=gpt-4o-mini,base_url=https://api.openai.com/v1/chat/completions,num_concurrent=1 \
+          --tasks gsm8k \
+          --apply_chat_template \
+          --num_fewshot 0 \
+          --limit 5 \
+          --output_path ./results
+    - name: Save results
+      condition: always
+      artifacts:
+        paths:
+          - results/**/*.json
+```

--- a/docs/workflows/simple-promptfoo-workflow.md
+++ b/docs/workflows/simple-promptfoo-workflow.md
@@ -1,0 +1,42 @@
+```yaml showLineNumbers title="Basic Promptfoo Workflow"
+kind: TestWorkflow
+apiVersion: testworkflows.testkube.io/v1
+metadata:
+  name: promptfoo-getting-started
+  namespace: testkube
+  labels:
+    type: ai
+spec:
+  content:
+    git:
+      uri: https://github.com/promptfoo/promptfoo.git
+      revision: main
+      cone: true
+      paths:
+        - examples/getting-started
+  container:
+    workingDir: /data/repo/examples/getting-started
+    image: node:22-bookworm-slim
+    env:
+      - name: HOME
+        value: /data
+      - name: PROMPTFOO_DISABLE_TELEMETRY
+        value: "1"
+      - name: CI
+        value: "true"
+      - name: OPENAI_API_KEY
+        value: '{{credential("OPENAI_API_KEY")}}'
+    resources:
+      requests:
+        cpu: 500m
+        memory: 1Gi
+  steps:
+    - name: Run promptfoo eval
+      shell: npx --yes promptfoo@latest eval -o results.json -o results.html
+    - name: Save report
+      condition: always
+      artifacts:
+        paths:
+          - results.json
+          - results.html
+```

--- a/docs/workflows/simple-ragas-workflow.md
+++ b/docs/workflows/simple-ragas-workflow.md
@@ -1,0 +1,76 @@
+```yaml showLineNumbers title="Basic Ragas Workflow"
+kind: TestWorkflow
+apiVersion: testworkflows.testkube.io/v1
+metadata:
+  name: ragas-getting-started
+  namespace: testkube
+  labels:
+    type: ai
+spec:
+  content:
+    files:
+      - path: /data/ragas_eval.py
+        content: |
+          import os
+          from ragas import EvaluationDataset, SingleTurnSample, evaluate
+          from ragas.metrics import Faithfulness, ResponseRelevancy
+          from ragas.llms import LangchainLLMWrapper
+          from ragas.embeddings import LangchainEmbeddingsWrapper
+          from langchain_openai import ChatOpenAI, OpenAIEmbeddings
+
+          llm = LangchainLLMWrapper(ChatOpenAI(model="gpt-4o-mini", temperature=0))
+          emb = LangchainEmbeddingsWrapper(OpenAIEmbeddings(model="text-embedding-3-small"))
+
+          samples = [
+              SingleTurnSample(
+                  user_input="Who wrote Hamlet?",
+                  response="Hamlet was written by William Shakespeare.",
+                  retrieved_contexts=["Shakespeare wrote the play Hamlet around 1600."],
+                  reference="William Shakespeare",
+              ),
+              SingleTurnSample(
+                  user_input="What is the capital of Sweden?",
+                  response="The capital of Sweden is Stockholm.",
+                  retrieved_contexts=["Stockholm is the capital and largest city of Sweden."],
+                  reference="Stockholm",
+              ),
+          ]
+
+          dataset = EvaluationDataset(samples=samples)
+          result = evaluate(
+              dataset=dataset,
+              metrics=[Faithfulness(), ResponseRelevancy()],
+              llm=llm,
+              embeddings=emb,
+          )
+          print(result)
+
+          os.makedirs("results", exist_ok=True)
+          result.to_pandas().to_json("results/ragas_results.json", orient="records", indent=2)
+          print("Wrote results/ragas_results.json")
+  container:
+    workingDir: /data
+    image: python:3.12-slim
+    env:
+      - name: HOME
+        value: /data
+      - name: RAGAS_DO_NOT_TRACK
+        value: "true"
+      - name: OPENAI_API_KEY
+        value: '{{credential("OPENAI_API_KEY")}}'
+    resources:
+      requests:
+        cpu: "1"
+        memory: 2Gi
+  steps:
+    - name: Install and run Ragas
+      shell: |
+        set -e
+        pip install --no-cache-dir "ragas>=0.2,<0.3" "langchain-openai>=0.2,<0.3" "langchain<0.4" "langchain-community<0.4" "langchain-core<0.4"
+        python ragas_eval.py
+    - name: Save results
+      condition: always
+      artifacts:
+        paths:
+          - results/*.json
+```

--- a/sidebars.js
+++ b/sidebars.js
@@ -1154,6 +1154,37 @@ const sidebars = {
         },
         {
           type: "category",
+          label: "AI Testing",
+          items: [
+            {
+              type: "doc",
+              label: "Promptfoo",
+              id: "articles/examples/promptfoo-basic",
+            },
+            {
+              type: "doc",
+              label: "DeepEval",
+              id: "articles/examples/deepeval-basic",
+            },
+            {
+              type: "doc",
+              label: "Inspect AI",
+              id: "articles/examples/inspect-ai-basic",
+            },
+            {
+              type: "doc",
+              label: "Ragas",
+              id: "articles/examples/ragas-basic",
+            },
+            {
+              type: "doc",
+              label: "LM Evaluation Harness",
+              id: "articles/examples/lm-eval-basic",
+            },
+          ],
+        },
+        {
+          type: "category",
           label: "Infrastructure Testing",
           items: [
             {


### PR DESCRIPTION
## Summary

- Adds a new **AI Testing** category under *Examples & Guides* with five example pages showing how Testkube can run different types of AI/LLM tests:
  - **Promptfoo** – runs the official getting-started eval and uploads JSON/HTML reports as artifacts
  - **DeepEval** – runs the same test suite against three OpenAI models in parallel via `parallel.matrix`, with JUnit reports ingested as structured test results
  - **Inspect AI** – inline eval task plus a quality-gate script that fails the workflow below an accuracy threshold
  - **Ragas** – RAG pipeline evaluation with Faithfulness and ResponseRelevancy metrics
  - **LM Evaluation Harness** – runs a slice of the `gsm8k` benchmark against an OpenAI model
- Workflow YAML snippets added under `docs/workflows/`, all resolving `OPENAI_API_KEY` via the `credential()` expression with a link to the credential-management docs
- Updates `sidebars.js` and the examples overview page accordingly

## Test plan

- [x] `npm run build` passes with no broken links or warnings for the new pages
- [ ] Review rendered pages locally via `npm run serve`

Made with [Cursor](https://cursor.com)