### PR TITLE
chore: postgres documentation updates

### DIFF
--- a/docs/articles/architecture.md
+++ b/docs/articles/architecture.md
@@ -142,12 +142,12 @@ Check the table to know each of the integrations between Testkube Components:
 |User Browser|Dex|User will reach Dex service for authentication process|5556|
 |User Browser|S3|User will reach Dex service for pulling test execution artifacts|9000|
 |Testkube Control Plane API|Dex|To verify user token and ensure authenticated access to Testkube platform|5556, 5557|
-|Testkube Control Plane API|MongoDB|To store the state of the whole platform objects (Test Workflows, Test Triggers, Webhooks, etc.)|27017 (If it's the default MongoDB deployed together with Testkube platform)|
+|Testkube Control Plane API|PostgreSQL|To store the state of the whole platform objects (Test Workflows, Test Triggers, Webhooks, etc.)|5432 (If it's the bundled PostgreSQL deployed together with Testkube platform)|
 |Testkube Control Plane API|NATS|To manage events happening into the platform|4222|
 |Testkube Control Plane API|S3|To store artifacts (test workflow execution results, logs, and metrics)|9000 (If is MinIO)| 
 |Testkube Control Plane API|_License Server **_|To validate license configured in instance, License Server is an external service managed by Testkube|443|
 |Worker Service|NATS|To manage events happening into the platform|4222|
-|Worker Service|MongoDB|To manage the state of the whole platform objects (Test Workflows, Test Triggers, Webhooks, etc.) generating metrics|27017 (If it's the default MongoDB deployed together with Testkube platform)|
+|Worker Service|PostgreSQL|To manage the state of the whole platform objects (Test Workflows, Test Triggers, Webhooks, etc.) generating metrics|5432 (If it's the bundled PostgreSQL deployed together with Testkube platform)|
 |Testkube Agent API|Testkube Control Plane API|To receive instructions on Test Workflow and other features execution in the specific environment and Kubernetes cluster|8089 (if HTTPS, 8443)|
 |Testkube Agent API|S3|To store artifacts (test workflow execution results, logs, and metrics)|9000 (If is MinIO)|
 |Testkube Agent API|NATS|To manage events happening into the platform|4222|
@@ -177,8 +177,8 @@ It provides 2 main interfaces:
 This component also integrates with:
 
 * **Dex:** using port `5556` and `5557` with TCP protocol.
-* **MongoDB:** using default port `27017` with TCP protocol.
 * **PostgreSQL:** using default port `5432` with TCP protocol.
+* **MongoDB:** using default port `27017` with TCP protocol (legacy deployments only).
 * **NATS**: using port `4222` with TCP protocol. It also apply to Testkube Agent API, unless it's configured to have embedded NATS.
 
 #### S3 or Object storage

--- a/docs/articles/argocd-integration.md
+++ b/docs/articles/argocd-integration.md
@@ -132,7 +132,10 @@ testkube-api:
     enabled: false
     
 mongodb:
-  enabled: false 
+  enabled: false
+
+postgresql:
+  enabled: false
   
 testkube-dashboard:
   enabled: false

--- a/docs/articles/install/3-install-with-helm.md
+++ b/docs/articles/install/3-install-with-helm.md
@@ -30,12 +30,12 @@ Before you proceed with the installation, please ensure that you have the follow
 
 The following are production requirements for external dependencies:
 
-- **PostgreSQL** *(default database)*
+- **PostgreSQL**
   - At least 500 millicore
   - 1GB of memory
   - At least 5GB of storage (subject to increase as load increases)
   
-- **MongoDB** *(legacy deployments only)*
+- **MongoDB**
   - At least 1 CPU core
   - 2GB of memory
   - At least 10GB of storage (subject to increase as load increases)

--- a/docs/articles/install/3-install-with-helm.md
+++ b/docs/articles/install/3-install-with-helm.md
@@ -30,12 +30,12 @@ Before you proceed with the installation, please ensure that you have the follow
 
 The following are production requirements for external dependencies:
 
-- **PostgreSQL**
+- **PostgreSQL** *(default database)*
   - At least 500 millicore
   - 1GB of memory
   - At least 5GB of storage (subject to increase as load increases)
   
-- **MongoDB**
+- **MongoDB** *(legacy deployments only)*
   - At least 1 CPU core
   - 2GB of memory
   - At least 10GB of storage (subject to increase as load increases)

--- a/docs/articles/install/4-advanced-install.md
+++ b/docs/articles/install/4-advanced-install.md
@@ -500,7 +500,7 @@ You can easily connect PostgreSQL to an external database by creating a Kubernet
 
 :::warning Important
 
-MongoDB has been deprecated as the primary database and will be removed from Testkube by the end of 2026. Please plan your migration to PostgreSQL at your earliest convenience.
+MongoDB has been deprecated as the primary database. Please plan your migration to PostgreSQL at your earliest convenience.
 
 :::
 

--- a/docs/articles/install/4-advanced-install.md
+++ b/docs/articles/install/4-advanced-install.md
@@ -421,7 +421,9 @@ Testkube supports integrating with existing infrastructure components such as Po
 
 ### PostgreSQL
 
-Starting with release `2.9`, PostgreSQL will be used as the primary database instead of MongoDB. Since both options are currently supported, you must first disable MongoDB and then enable PostgreSQL in your `values.yaml` file. We strongly recommend using `CloudNativePG` instead of plain PostgreSQL, as it offloads much of the database management, and the installation of PostgreSQL by Bitnami will be deprecated by the end of 2026.
+PostgreSQL is the primary and default database for Testkube. New installations use PostgreSQL by default. For production environments, we strongly recommend using `CloudNativePG` instead of plain PostgreSQL, as it offloads much of the database management, and the installation of PostgreSQL by Bitnami will be deprecated by the end of 2026.
+
+If you are migrating from a legacy MongoDB deployment, disable MongoDB and enable PostgreSQL in your `values.yaml` file as shown below. Fresh installations already use PostgreSQL by default.
 The operator-based path has two parts:
 
 1. The `cloudnative-pg` operator, which manages PostgreSQL lifecycle in Kubernetes.
@@ -502,10 +504,9 @@ MongoDB has been deprecated as the primary database and will be removed from Tes
 
 :::
 
-Testkube uses [MongoDB](https://www.mongodb.com/) as a database for storing all the data.
-By default, it will install a MongoDB instance using the Bitnami MongoDB Helm chart.
+Testkube previously used [MongoDB](https://www.mongodb.com/) as its database. MongoDB is no longer installed by default and is retained only for legacy deployments and migration workflows.
 
-If you wish to use an existing MongoDB instance, you can configure the following values:
+If you still need to use an existing MongoDB instance, you can configure the following values:
 
 ```yaml
 mongodb:
@@ -531,6 +532,11 @@ testkube-api:
 ```
 
 #### MongoDB upgrade from 8.0.15 to 8.2.5
+
+:::note
+This section applies only to legacy MongoDB deployments. New installations use PostgreSQL by default.
+:::
+
 Starting with chart version `2.329.0`, MongoDB is upgraded to `8.2.3` and in the later versions to `8.2.5`.  This is a **breaking change** for installations that are not already running MongoDB `8.0.x`, because MongoDB requires the upgrade path to go through `8.0` before moving to `8.2.x`.
 
 To upgrade safely, you must first ensure they you on at least chart version `2.326.3`, which includes MongoDB `8.0.15`. Only after that should you upgrade to the latest chart version.

--- a/docs/articles/install/4-advanced-install.md
+++ b/docs/articles/install/4-advanced-install.md
@@ -533,10 +533,6 @@ testkube-api:
 
 #### MongoDB upgrade from 8.0.15 to 8.2.5
 
-:::note
-This section applies only to legacy MongoDB deployments. New installations use PostgreSQL by default.
-:::
-
 Starting with chart version `2.329.0`, MongoDB is upgraded to `8.2.3` and in the later versions to `8.2.5`.  This is a **breaking change** for installations that are not already running MongoDB `8.0.x`, because MongoDB requires the upgrade path to go through `8.0` before moving to `8.2.x`.
 
 To upgrade safely, you must first ensure they you on at least chart version `2.326.3`, which includes MongoDB `8.0.15`. Only after that should you upgrade to the latest chart version.

--- a/docs/articles/install/deploy-on-aws-eks.md
+++ b/docs/articles/install/deploy-on-aws-eks.md
@@ -447,8 +447,7 @@ development or evaluation deployments.
 
 :::warning
 
-MongoDB is deprecated as the primary database and will be removed from Testkube by the end of 2026. Use
-this section only for legacy deployments or while migrating to PostgreSQL. See
+Use this section only for legacy deployments or while migrating to PostgreSQL. See
 [Mongo to Postgres Migration](/articles/convert).
 
 :::

--- a/docs/articles/install/deploy-on-aws-eks.md
+++ b/docs/articles/install/deploy-on-aws-eks.md
@@ -2,7 +2,7 @@
 
 This guide walks through deploying Testkube On-Prem on an existing **Amazon EKS** cluster. It covers
 prerequisites, S3 storage configuration with two authentication methods (EKS Pod Identity and IRSA),
-MongoDB Atlas connectivity, ingress setup, and production hardening.
+PostgreSQL connectivity, ingress setup, and production hardening.
 
 :::info
 A ready-to-use reference repository with all configuration files, IAM templates, and install scripts
@@ -19,7 +19,8 @@ You can clone it and customise the values files for your environment.
 | kubectl | configured for the target cluster |
 | [cert-manager](https://cert-manager.io/docs/installation/) *(recommended)* | 1.11+ |
 | [NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/) *(recommended)* | 1.8+ |
-| MongoDB Atlas *(when using external MongoDB)* | Atlas cluster reachable from the EKS VPC |
+| PostgreSQL *(when using an external database)* | RDS, Aurora, or other PostgreSQL instance reachable from the EKS VPC |
+| MongoDB Atlas *(legacy deployments only)* | Atlas cluster reachable from the EKS VPC |
 
 :::warning IMPORTANT
 Use the community [kubernetes/ingress-nginx](https://artifacthub.io/packages/helm/ingress-nginx/ingress-nginx) chart —
@@ -115,8 +116,12 @@ global:
 Configure your identity provider connector under `dex.configTemplate.additionalConfig`.
 See [SSO / Identity Providers](/articles/auth) for detailed examples.
 
-If you use MongoDB Atlas instead of the chart-managed MongoDB, configure `global.mongo.dsn`
-with your Atlas connection string. See [Configure MongoDB Atlas](#6-configure-mongodb-atlas) below.
+If you use an external PostgreSQL database instead of the chart-managed PostgreSQL, configure
+`global.postgres.dsn` or `global.postgres.secretRef` with your connection details. See
+[Configure the Database](#6-configure-the-database) below.
+
+For legacy MongoDB Atlas deployments, configure `global.mongo.dsn` with your Atlas connection string.
+See [MongoDB Atlas (legacy)](#mongodb-atlas-legacy) below.
 
 ## 5. Configure S3 Storage
 
@@ -206,8 +211,9 @@ SDK falls back to IAM-based authentication.
 EKS Pod Identity eliminates the need for OIDC provider configuration and service account annotations.
 The Pod Identity Agent runs as a DaemonSet and injects credentials directly into pods.
 
-Use this option when Testkube pods need AWS credentials for S3, or when MongoDB Atlas users authenticate
-with AWS IAM using `authMechanism=MONGODB-AWS`.
+Use this option when Testkube pods need AWS credentials for S3. If you are running a legacy MongoDB
+Atlas deployment with AWS IAM authentication (`authMechanism=MONGODB-AWS`), the same IAM role can also
+be used for Atlas access.
 
 **Step 1 — Install the Pod Identity Agent addon:**
 
@@ -414,11 +420,41 @@ testkube-worker-service:
       eks.amazonaws.com/role-arn: "arn:aws:iam::<AWS_ACCOUNT_ID>:role/TestkubeS3Role"
 ```
 
-## 6. Configure MongoDB Atlas
+## 6. Configure the Database
 
-Testkube requires MongoDB for control-plane data. For AWS deployments, MongoDB Atlas can be reached
-through public networking with Atlas IP access lists or through Atlas PrivateLink. PrivateLink is
-recommended for production.
+PostgreSQL is the default database for Testkube control-plane data. New Helm installations include a
+bundled PostgreSQL instance. For production EKS deployments, use Amazon RDS, Aurora PostgreSQL, or
+[CloudNativePG](/articles/install/advanced-install#postgresql).
+
+### External PostgreSQL (recommended for production)
+
+Point Testkube at your managed database using `global.postgres.dsn` or `global.postgres.secretRef`.
+See [Advanced Install - PostgreSQL](/articles/install/advanced-install#postgresql) for full configuration
+options.
+
+```yaml
+global:
+  postgres:
+    dsn: "postgresql://<USER>:<PASSWORD>@<RDS_ENDPOINT>:5432/<DATABASE>?sslmode=require"
+```
+
+### Chart-managed PostgreSQL
+
+The default Helm installation includes PostgreSQL. No additional database configuration is required for
+development or evaluation deployments.
+
+### MongoDB Atlas (legacy)
+
+:::warning
+
+MongoDB is deprecated as the primary database and will be removed from Testkube by the end of 2026. Use
+this section only for legacy deployments or while migrating to PostgreSQL. See
+[Mongo to Postgres Migration](/articles/convert).
+
+:::
+
+For legacy AWS deployments, MongoDB Atlas can be reached through public networking with Atlas IP access
+lists or through Atlas PrivateLink. PrivateLink is recommended for production.
 
 ### MongoDB Atlas Connection String
 
@@ -675,13 +711,14 @@ testkube-cloud-api:
             topologyKey: "kubernetes.io/hostname"
 ```
 
-**Storage class:** Use `gp3` for EBS-backed PersistentVolumes (MongoDB, NATS):
+**Storage class:** Use `gp3` for EBS-backed PersistentVolumes (PostgreSQL, NATS):
 
 ```yaml
-mongodb:
-  persistence:
-    storageClass: "gp3"
-    size: 50Gi
+postgresql:
+  primary:
+    persistence:
+      storageClass: "gp3"
+      size: 50Gi
 ```
 
 ## Troubleshooting
@@ -726,7 +763,14 @@ aws eks describe-cluster --name <EKS_CLUSTER_NAME> \
 - Verify HTTP/2 is supported end-to-end through your ingress / load balancer.
 - If using ALB, confirm the target group protocol and check for HTTP/2 support.
 
-**MongoDB Atlas connection errors:**
+**PostgreSQL connection errors:**
+
+- `connection refused` or timeout: verify security groups, subnet routing, and that the RDS or Aurora
+  endpoint is reachable from the EKS VPC.
+- `password authentication failed`: verify credentials in `global.postgres.dsn` or the referenced secret.
+- `SSL required`: add `sslmode=require` (or your provider's required mode) to the PostgreSQL DSN.
+
+**MongoDB Atlas connection errors (legacy):**
 
 - `lookup ... no such host` or `NXDOMAIN`: verify the Atlas PrivateLink DNS name and VPC DNS settings
   from inside the cluster.

--- a/docs/articles/install/standalone-agent.md
+++ b/docs/articles/install/standalone-agent.md
@@ -157,10 +157,6 @@ When [minio](https://min.io/) is specified, logs will be stored as separate file
 
 ### MongoDB upgrade from 8.0.13 to 8.2.5
 
-:::note
-This section applies only to legacy MongoDB deployments. New installations use PostgreSQL by default.
-:::
-
 Starting with chart version `2.6.0`, MongoDB is upgraded to `8.2.3` and in the later versions to `8.2.5`.  This is a **breaking change** for installations that are not already running MongoDB `8.0.x`, because MongoDB requires the upgrade path to go through `8.0` before moving to `8.2.x`.
 
 To upgrade safely, you must first ensure they you on at least chart version `2.4.0`, which includes MongoDB `8.0.13`. Only after that should you upgrade to the latest chart version.

--- a/docs/articles/install/standalone-agent.md
+++ b/docs/articles/install/standalone-agent.md
@@ -157,6 +157,10 @@ When [minio](https://min.io/) is specified, logs will be stored as separate file
 
 ### MongoDB upgrade from 8.0.13 to 8.2.5
 
+:::note
+This section applies only to legacy MongoDB deployments. New installations use PostgreSQL by default.
+:::
+
 Starting with chart version `2.6.0`, MongoDB is upgraded to `8.2.3` and in the later versions to `8.2.5`.  This is a **breaking change** for installations that are not already running MongoDB `8.0.x`, because MongoDB requires the upgrade path to go through `8.0` before moving to `8.2.x`.
 
 To upgrade safely, you must first ensure they you on at least chart version `2.4.0`, which includes MongoDB `8.0.13`. Only after that should you upgrade to the latest chart version.
@@ -239,25 +243,23 @@ Alternatively, these values can be read from Kubernetes secrets and set:
 
 To install the standalone agent Testkube on an Openshift cluster you will need to include the following configuration:
 
-1. Add security context for MongoDB to `values.yaml`:
+1. Add security context for PostgreSQL to `values.yaml`:
 
 ```yaml
-mongodb:
-  securityContext:
-    enabled: true
-    fsGroup: 1000650001
-    runAsUser: 1000650001
-  podSecurityContext:
-    enabled: false
-  containerSecurityContext:
-    enabled: true
-    runAsUser: 1000650001
-    runAsNonRoot: true
+postgresql:
+  primary:
+    podSecurityContext:
+      enabled: false
+    containerSecurityContext:
+      enabled: false
   volumePermissions:
     enabled: false
-  auth:
-    enabled: false
+  shmVolume:
+    chmod:
+      enabled: false
 ```
+
+If you are running a legacy MongoDB deployment on OpenShift, use the MongoDB security context settings in the [Helm chart values](https://github.com/kubeshop/helm-charts/blob/main/charts/testkube/values.yaml) instead.
 
 2. The Testkube Operator is deprecated and disabled by default. If your installation previously used it, ensure it is disabled in `values.yaml`:
 
@@ -272,11 +274,13 @@ testkube-operator:
 helm install testkube oci://us-east1-docker.pkg.dev/testkube-cloud-372110/testkube/testkube --version <version> --create-namespace --namespace testkube --values values.yaml
 ```
 
-Please notice that since we've just installed MongoDB with a `testkube-mongodb` Helm release name, you are not required to reconfigure the Testkube API MongoDB connection URI. If you've installed with a different name/namespace, please adjust `--set testkube-api.mongodb.dsn: "mongodb://testkube-mongodb:27017"` to your MongoDB service.
+By default, the bundled PostgreSQL instance is reachable at `testkube-postgresql`. No additional database connection configuration is required unless you use a different release name or namespace.
 
-## Using PostgreSQL as a database
+## Database
 
-Starting with release `2.9`, PostgreSQL will be used as the primary database instead of MongoDB. Since both options are currently supported, you must first disable MongoDB and then enable PostgreSQL in your `values.yaml` file. We strongly recommend using `CloudNativePG` instead of plain PostgreSQL, as it offloads much of the database management, and the installation of PostgreSQL by Bitnami will be deprecated by the end of 2026.
+PostgreSQL is the primary and default database for Testkube. New installations use PostgreSQL by default. For production environments, we strongly recommend using `CloudNativePG` instead of plain PostgreSQL, as it offloads much of the database management, and the installation of PostgreSQL by Bitnami will be deprecated by the end of 2026.
+
+If you are migrating from a legacy MongoDB deployment, disable MongoDB and enable PostgreSQL in your `values.yaml` file as shown below. Fresh installations already use PostgreSQL by default.
 
 The operator-based path has two parts:
 

--- a/docs/articles/legacy-architecture.mdx
+++ b/docs/articles/legacy-architecture.mdx
@@ -18,7 +18,7 @@ These diagrams were made with the [C4 diagram technique](https://c4model.com/). 
 
 ![testkube container diagram](../img/containers.png)
 
-See also [Dependencies for Testkube](../articles/mongodb-administration.md) describing NATS, MinIO and MongoDB dependencies.
+See also [Dependencies for Testkube](../articles/mongodb-administration.md) describing NATS, MinIO, PostgreSQL, and legacy MongoDB dependencies.
 
 ### Components
 


### PR DESCRIPTION
Postgres is now the recommended database for Testkube. This PR updates the documentation to indicate this.