### PR TITLE
chore: add 2.12.0 changelog skeleton

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -29,6 +29,12 @@ Control Plane is available in Helm chart `v2.335.0` and the Agent is available i
 
 - Login and signup are now separate pages.
 
+### Improvements
+
+- Registration token rotation: from the Testkube CLI, it is now possible to rotate the registration token that agents use to self-register with the Control Plane. Once updated, the token must be updated in all locations where it is used: values.yaml files and/or secret stores.
+- Testkube CLI supports `--limit` for queries: the CLI now allows the `--limit` parameter for the Test Workflow `get` method to return more than 100 objects.
+- CVEs resolution: all vulnerabilities (CVEs) reported in previous versions of the images have been resolved, for both the Control Plane and Agent artifact groups.
+
 ### Other
 
 - Added ability to filter executions based on actor and execution time

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -16,7 +16,8 @@ Control Plane is available in Helm chart `v2.335.0` and the Agent is available i
 
 ### AI
 
-- _AI Squad to complete_
+- Private AI chats. Start a private chat to keep the conversation visible only to you, then make it public when you're ready to share it with your team. Making a chat public is permanent.
+- AI chats in workflow and execution context. Workflow details now include an AI Chats tab, while the existing execution tab now shows any chat where an agent inspected that workflow or execution, not only chats started by triggers, making related analysis easier to find and continue.
 
 ### Test & Git Triggers
 

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -8,6 +8,40 @@ This is the changelog for the Testkube Control Plane, latest releases are on top
 - **Doc updates** focus on major changes to the documentation
   :::
 
+## Release v2.12.0 (2026-07-23)
+
+This is a major release with lots of new features and improvements!
+
+Control Plane is available in Helm chart `vX.XXX.X` and the Agent is available in Helm chart `vX.XX.X`.
+
+### AI
+
+- _AI Squad to complete_
+
+### Test & Git Triggers
+
+- _to complete_
+
+### Insights & Analytics
+
+- _Data & Analytics Squad to complete_
+
+### Operations & Security
+
+- Login and signup are now separate pages.
+
+#### Helm Charts
+
+- _to complete_
+
+### Runner Agent
+
+- _to complete_
+
+### Fixes
+
+- _to complete_
+
 ## Patch Release v2.11.3 (2026-07-17)
 
 Control Plane is available in Helm chart `v2.334.3`.

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -12,7 +12,7 @@ This is the changelog for the Testkube Control Plane, latest releases are on top
 
 This is a major release with lots of new features and improvements!
 
-Control Plane is available in Helm chart `vX.XXX.X` and the Agent is available in Helm chart `vX.XX.X`.
+Control Plane is available in Helm chart `v2.335.0` and the Agent is available in Helm chart `v2.12.0`.
 
 ### AI
 

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -36,6 +36,8 @@ Control Plane is available in Helm chart `v2.335.0` and the Agent is available i
 - Added extra details to logs pertaining to workflow, execution, and runner metadata
 - Replaced outdated Grafana dashboard metrics with their current corresponding ones
 - Added `--limit` support to the CLI for `get tw` and `get tw template` commands
+- Added an option to expose Prometheus metrics for runners
+- Improved runner logging to reduce false error messages
 
 
 ## Patch Release v2.11.3 (2026-07-17)

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -41,7 +41,6 @@ Control Plane is available in Helm chart `v2.335.0` and the Agent is available i
 - Improved error messages when editing workflow and other definitions via YAML
 - Added extra details to logs pertaining to workflow, execution, and runner metadata
 - Replaced outdated Grafana dashboard metrics with their current corresponding ones
-- Added `--limit` support to the CLI for `get tw` and `get tw template` commands
 - Added an option to expose Prometheus metrics for runners
 - Improved runner logging to reduce false error messages
 

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -35,6 +35,7 @@ Control Plane is available in Helm chart `v2.335.0` and the Agent is available i
 - Improved error messages when editing workflow and other definitions via YAML
 - Added extra details to logs pertaining to workflow, execution, and runner metadata
 - Replaced outdated Grafana dashboard metrics with their current corresponding ones
+- Added `--limit` support to the CLI for `get tw` and `get tw template` commands
 
 
 ## Patch Release v2.11.3 (2026-07-17)

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -19,10 +19,6 @@ Control Plane is available in Helm chart `v2.335.0` and the Agent is available i
 - Private AI chats. Start a private chat to keep the conversation visible only to you, then make it public when you're ready to share it with your team. Making a chat public is permanent.
 - AI chats in workflow and execution context. Workflow details now include an AI Chats tab, while the existing execution tab now shows any chat where an agent inspected that workflow or execution, not only chats started by triggers, making related analysis easier to find and continue.
 
-### Test & Git Triggers
-
-- _to complete_
-
 ### Insights & Analytics
 
 - Added support for execution drilldown on all metrics
@@ -33,14 +29,6 @@ Control Plane is available in Helm chart `v2.335.0` and the Agent is available i
 
 - Login and signup are now separate pages.
 
-#### Helm Charts
-
-- _to complete_
-
-### Runner Agent
-
-- _to complete_
-
 ### Other
 
 - Added ability to filter executions based on actor and execution time
@@ -48,9 +36,6 @@ Control Plane is available in Helm chart `v2.335.0` and the Agent is available i
 - Added extra details to logs pertaining to workflow, execution, and runner metadata
 - Replaced outdated Grafana dashboard metrics with their current corresponding ones
 
-### Fixes
-
-- _to complete_
 
 ## Patch Release v2.11.3 (2026-07-17)
 

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -25,7 +25,9 @@ Control Plane is available in Helm chart `v2.335.0` and the Agent is available i
 
 ### Insights & Analytics
 
-- _Data & Analytics Squad to complete_
+- Added support for execution drilldown on all metrics
+- Added support for filtering or segmenting by execution tags in time series analysis
+- Extended available segments for dynamic and custom metrics
 
 ### Operations & Security
 
@@ -38,6 +40,12 @@ Control Plane is available in Helm chart `v2.335.0` and the Agent is available i
 ### Runner Agent
 
 - _to complete_
+
+### Other
+
+- Added ability to filter executions based on actor and execution time
+- Improved error messages when editing workflow and other definitions via YAML
+- Added extra details to logs pertaining to workflow, execution, and runner metadata
 
 ### Fixes
 

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -46,6 +46,7 @@ Control Plane is available in Helm chart `v2.335.0` and the Agent is available i
 - Added ability to filter executions based on actor and execution time
 - Improved error messages when editing workflow and other definitions via YAML
 - Added extra details to logs pertaining to workflow, execution, and runner metadata
+- Replaced outdated Grafana dashboard metrics with their current corresponding ones
 
 ### Fixes
 


### PR DESCRIPTION
Changelog scaffold for the 2.12.0 release (targets release/2-12 so it won't publish before Thursday).

Squads: please fill in your sections (AI, Test & Git Triggers, Insights & Analytics, Operations & Security + Helm Charts, Runner Agent, Fixes) directly on this branch or in the #tk-release thread.

TODO before release:
- Fill Helm chart versions (Control Plane + Agent)
  - Confirm the login/signup entry (TKC-6038) stays or is reverted for on-prem
  - Add the missing 2.11.2 changelog entry