### PR TITLE
docs: explain multi-group role assignment in the SCIM guide

### DIFF
--- a/docs/articles/scim.md
+++ b/docs/articles/scim.md
@@ -2,20 +2,20 @@
 
 ## Overview
 
-SCIM (System for Cross-domain Identity Management) is a standard protocol that automates user and group management between your identity provider (IdP) — like Okta or Azure AD — and Testkube.  
-With SCIM, user provisioning and deprovisioning happen automatically:
+SCIM (System for Cross-domain Identity Management) is a standard protocol that automates user and group management between your identity provider (IdP), such as Okta or Azure AD, and Testkube.  
+With SCIM, provisioning and deprovisioning are automatic:
 
-- When a user is added to your organization in your IdP, they immediately receive access to Testkube.
-- When a user is removed from your IdP, their Testkube access is revoked right away.
+- When you add a user to your organization in the IdP, the user gets access to Testkube.
+- When you remove a user from the IdP, Testkube revokes their access.
 
-This removes the need for manual account management and ensures your organization stays in sync.
+You do not manage accounts manually, and the organization stays in sync with the IdP.
 
 ### Key Benefits
 
-- **Automated provisioning** – Users and groups are created and updated automatically.
-- **Team synchronization** – IdP groups map directly to Testkube teams.
-- **Granular access control** – Assign permissions to organizations, environments, and resource groups.
-- **Security compliance** – Automatic deprovisioning keeps your org secure when users leave.
+- Testkube creates and updates users and groups automatically.
+- IdP groups map directly to Testkube teams.
+- You can assign permissions to organizations, environments, and resource groups.
+- Automatic deprovisioning removes access when users leave.
 
 ---
 
@@ -29,15 +29,15 @@ SCIM is configured per organization.
 
 1. In the Testkube dashboard, go to **Organization Management → Product Features**.
 2. Enable **SCIM**.
-3. Copy the **SCIM API token** that is generated — keep it safe, you’ll need it for authentication.
-4. Note your organization’s **SCIM endpoint URL**:
+3. Copy the generated **SCIM API token** and keep it safe. You need it for authentication.
+4. Note your organization's **SCIM endpoint URL**:
    ```
    https://<testkube-domain>/organizations/<org_id>/scim
    ```
 
 ### Step 2: Configure Your Identity Provider
 
-In your IdP’s SCIM configuration:
+In your IdP's SCIM configuration:
 
 - **Base URL**:
   ```
@@ -45,17 +45,17 @@ In your IdP’s SCIM configuration:
   ```
 - **Authentication**: Bearer Token (use the SCIM API token from Step 1)
 
-> ⚠️ The SCIM endpoint is organization-specific and will only manage users and teams for that organization.
+> ⚠️ The SCIM endpoint is specific to one organization. It manages users and teams only for that organization.
 
-> ⚠️ Testkube identifies users by email. Map your IdP's `userName` to the user's email address (for example, `userPrincipalName` in Entra ID, or the Email field in Okta). If `userName` is set to anything else, Testkube can't reliably match users, and you end up with duplicate accounts or updates that silently do nothing.
+> ⚠️ Testkube identifies users by email. Map your IdP's `userName` to the user's email address (for example, `userPrincipalName` in Entra ID, or the Email field in Okta). If `userName` is set to anything else, Testkube cannot match users reliably, and you get duplicate accounts or updates that silently do nothing.
 
-> 📘 The settings above are enough to connect. For full step-by-step setup — including how to assign roles and entitlements and which response format to use — follow the guide for your provider: [Okta](#okta) or [Microsoft Entra ID (Azure AD)](#microsoft-entra-id-azure-ad).
+> 📘 The settings above are enough to connect. For the full setup, including roles, entitlements, and the response format, follow the guide for your provider: [Okta](#okta) or [Microsoft Entra ID (Azure AD)](#microsoft-entra-id-azure-ad).
 
 ---
 
 ## Manage Permissions in Testkube
 
-When SCIM is enabled, roles and resource assignments are controlled by your IdP via the `roles` and `entitlements` custom attributes.
+When SCIM is enabled, your IdP controls roles and resource assignments via the `roles` and `entitlements` custom attributes.
 The **Manage permissions in Testkube** checkbox lets admins manage these directly in Testkube instead, while SCIM still handles user and team provisioning.
 
 Enable this in **Organization Management → Product Features** after enabling SCIM.
@@ -66,7 +66,7 @@ With this option enabled:
 - `roles` and `entitlements` attributes from SCIM requests are ignored.
 - Admins assign organization roles, environment access, and resource group access in the Testkube dashboard.
 
-This is useful in cases where custom attributes `roles` and `entitlements` cannot be defined on the IdP side.
+Use this option when you cannot define the `roles` and `entitlements` custom attributes on the IdP side.
 
 ---
 
@@ -74,9 +74,9 @@ This is useful in cases where custom attributes `roles` and `entitlements` canno
 
 Testkube uses **URNs (Uniform Resource Names)** to define roles. A role URN specifies what permissions a user has for a particular resource.
 
-All of the settings below are configured on your Identity Provider side, so each user should have a `roles` attribute containing an array of strings.
+You configure the settings below on the IdP side. Each user gets a `roles` attribute that contains an array of strings.
 
-> 💡 Always reference environments and resource groups by their **ID or slug**, never their display name. A URN built from a display name won't match an existing resource, so the role is dropped. For entitlements it's worse: Testkube creates a brand-new resource with that name instead of using the one you meant.
+> 💡 Always reference environments and resource groups by their **ID or slug**, never their display name. A URN built from a display name does not match an existing resource, so Testkube drops the role. For entitlements the effect is worse: Testkube creates a new resource with that name instead of the one you meant.
 
 ### Organization Roles
 
@@ -92,10 +92,10 @@ Here `my-org` is your organization's ID or slug. Because the SCIM endpoint alrea
 
 Available roles:
 
-- **owner** – Full control over the organization and all resources
-- **admin** – Manage organization settings, members, and teams
-- **biller** – Manage billing and subscriptions
-- **member** – Basic access without administrative privileges
+- **owner**: Full control over the organization and all resources
+- **admin**: Manage organization settings, members, and teams
+- **biller**: Manage billing and subscriptions
+- **member**: Basic access without administrative privileges
 
 #### Wildcards
 
@@ -127,9 +127,9 @@ Example:
 
 Available roles:
 
-- **admin** – Full control of the environment
-- **write** – Run tests, edit configs, view results
-- **read** – View-only access
+- **admin**: Full control of the environment
+- **write**: Run tests, edit configs, view results
+- **read**: View-only access
 
 #### Wildcards
 
@@ -177,10 +177,10 @@ Example:
 
 If multiple roles could apply, Testkube uses this order:
 
-1. Exact ID match (highest priority) – `environment:env-123:admin`
-2. Slug match – `environment:production:write`
-3. Wildcard – `environment:*:read`
-4. System default (lowest) – usually `member` or `read`
+1. Exact ID match (highest priority): `environment:env-123:admin`
+2. Slug match: `environment:production:write`
+3. Wildcard: `environment:*:read`
+4. System default (lowest): usually `member` or `read`
 
 Example:
 
@@ -194,7 +194,7 @@ Example:
 }
 ```
 
-Result: User has read access everywhere, but full admin in `production`.
+Result: the user has read access in all environments and admin access in `production`.
 
 ---
 
@@ -202,7 +202,7 @@ Result: User has read access everywhere, but full admin in `production`.
 
 Entitlements assign users or teams to environments or resource groups. An entitlement grants membership with read access. For more than read access, also assign an environment or resource group role from [Role Management](#role-management).
 
-All of the settings below are configured on your Identity Provider side, so each user should have an `entitlements` attribute containing an array of strings.
+You configure the settings below on the IdP side. Each user gets an `entitlements` attribute that contains an array of strings.
 
 Example:
 
@@ -222,19 +222,19 @@ Example:
 
 ## Roles and Entitlements Format
 
-Identity providers don't agree on how to send multi-valued attributes like `roles` and `entitlements`. Testkube understands both shapes:
+Identity providers send multi-valued attributes like `roles` and `entitlements` in two different shapes. Testkube understands both:
 
 | Shape                                                                           | Example                                                 | Used by                 |
 | ------------------------------------------------------------------------------- | ------------------------------------------------------- | ----------------------- |
 | Simple (default)                                                                | `["urn:testkube:role:organization:*:admin"]`            | Okta and most providers |
 | Complex ([RFC 7643](https://datatracker.ietf.org/doc/html/rfc7643#section-2.4)) | `[{"value": "urn:testkube:role:organization:*:admin"}]` | Microsoft Entra ID      |
 
-Testkube accepts **both shapes on input**, so creating and updating users always works. The setting only changes the shape Testkube uses in its **responses** — the shape your IdP reads back when it imports users or reconciles state.
+Testkube accepts **both shapes on input**, so create and update requests always work. The setting only changes the shape Testkube uses in its **responses**: the shape your IdP reads back when it imports users or reconciles state.
 
 **Pick the shape your IdP expects**, because the IdP parses Testkube's responses against its own schema and the wrong one breaks that read-back:
 
-- **Okta** expects strings, so keep the default (simple). If you switch an Okta organization to complex, Okta's user import fails with `Invalid value data type` — it receives objects where it expects strings.
-- **Entra ID** expects objects, so turn complex on. With the simple shape, Entra can't reconcile what it reads back against what it provisioned.
+- **Okta** expects strings, so keep the default (simple). If you switch an Okta organization to complex, Okta's user import fails with `Invalid value data type` because Okta receives objects where it expects strings.
+- **Entra ID** expects objects, so turn complex on. With the simple shape, Entra cannot reconcile what it reads back against what it provisioned.
 
 Turn complex on under **Organization Management → Product Features → SCIM** by checking **Use RFC 7643 complex format for roles & entitlements**. The setting is per organization, so point Okta at a simple-format organization and Entra at a complex-format one.
 
@@ -267,8 +267,8 @@ Example:
 }
 ```
 
-- All team members inherit the team’s roles.
-- Adding/removing a user in the IdP updates their access in Testkube automatically.
+- All team members inherit the team's roles.
+- When you add or remove a user in the IdP, Testkube updates their access automatically.
 
 ---
 
@@ -278,19 +278,19 @@ Testkube supports **SCIM 2.0** with these operations:
 
 ### User Operations
 
-- **CREATE** – Add new users
-- **READ** – Get user info
-- **UPDATE (PUT)** – Replace all user data
-- **UPDATE (PATCH)** – Update specific attributes
-- **DELETE** – Remove users
+- **CREATE**: Add new users
+- **READ**: Get user info
+- **UPDATE (PUT)**: Replace all user data
+- **UPDATE (PATCH)**: Update specific attributes
+- **DELETE**: Remove users
 
 ### Group Operations
 
-- **CREATE** – Create new teams
-- **READ** – Get team info
-- **UPDATE (PUT)** – Replace all team data
-- **UPDATE (PATCH)** – Add/remove team members
-- **DELETE** – Delete teams
+- **CREATE**: Create new teams
+- **READ**: Get team info
+- **UPDATE (PUT)**: Replace all team data
+- **UPDATE (PATCH)**: Add/remove team members
+- **DELETE**: Delete teams
 
 ---
 
@@ -323,7 +323,7 @@ testkube-cloud-api:
 SCIM_SERVER_ENABLED=true
 ```
 
-Afterwards enable SCIM integration in the desired organization via the dashboard.
+Then enable SCIM for the organization in the dashboard.
 
 ---
 
@@ -331,9 +331,9 @@ Afterwards enable SCIM integration in the desired organization via the dashboard
 
 ### Users cannot log in
 
-- Ensure user is provisioned via SCIM
-- Check email matches IdP credentials
-- Review IdP provisioning logs
+- Make sure the user is provisioned via SCIM.
+- Check that the email matches the IdP credentials.
+- Review the IdP provisioning logs.
 
 ### Roles or entitlements not applied
 
@@ -346,9 +346,9 @@ Afterwards enable SCIM integration in the desired organization via the dashboard
 
 ### SCIM request failures
 
-- Confirm bearer token is correct
-- Review SCIM server logs in control plane api
-- Verify endpoint is accessible from your network
+- Confirm that the bearer token is correct.
+- Review the SCIM server logs in the control plane API.
+- Verify that the endpoint is reachable from your network.
 
 ---
 
@@ -362,7 +362,7 @@ Afterwards enable SCIM integration in the desired organization via the dashboard
 
 ### Okta
 
-This guide walks you through integrating Okta with Testkube for **SCIM provisioning**.
+This guide integrates Okta with Testkube for **SCIM provisioning**.
 
 ### Prerequisites
 
@@ -378,7 +378,7 @@ This guide walks you through integrating Okta with Testkube for **SCIM provision
 
 1. In the left sidebar, navigate to **Applications** → **Applications**.
 2. Click **Create App Integration**.
-3. Choose **SWA – Secure Web Authentication**.
+3. Choose **SWA (Secure Web Authentication)**.
 4. Set the **Application username** to **Email**.
 5. Save the new application.
 
@@ -411,12 +411,12 @@ This guide walks you through integrating Okta with Testkube for **SCIM provision
 
 1. Save the configuration.
 2. SCIM provisioning between Okta and Testkube is now active.
-3. You can now assign users and groups to this application, and they will be provisioned into Testkube automatically.
+3. You can now assign users and groups to this application, and Testkube provisions them automatically.
 
 ### Defining Roles and Entitlements in Okta
 
-When integrating Okta with Testkube via SCIM, you may want to assign additional `roles` (permissions) and `entitlements` (resource memberships) to users or groups.
-This is done by defining extra attributes in Okta and mapping them to Testkube.
+With SCIM, you can assign `roles` (permissions) and `entitlements` (resource memberships) to users or groups.
+To do this, define extra attributes in Okta and map them to Testkube.
 
 #### Step 1. Add Custom Attributes in Okta
 
@@ -442,7 +442,7 @@ This is done by defining extra attributes in Okta and mapping them to Testkube.
 
 #### Step 3. Set the Values on Users or Groups
 
-Mapping the attributes only tells Okta where to send them — you still set the actual URN values:
+The mappings only tell Okta where to send the attributes. You still set the URN values:
 
 - **Per user:** go to **Directory** → **People**, open a user, then **Profile** → **Edit Attributes**, and set `roles` and `entitlements` to the Testkube URNs (for example, `urn:testkube:role:organization:*:admin` and `urn:testkube:entitlement:environment:staging`).
 - **For many users at once:** set the values on an Okta **group**, then push the group to the app so everyone in it inherits the same roles and entitlements.
@@ -543,7 +543,7 @@ Notes on the complex mappings:
 
 #### Step 5. Send Entitlements (optional)
 
-Entra has no built-in source for `entitlements`, and `entitlements` isn't in its default attribute list. To send them, open **Provisioning** → **Mappings** → **Show advanced options** → **Edit attribute list**, add `entitlements`, then map it from a constant value or a directory extension attribute that holds the URN. For most setups, granting environment and resource group access through **roles** (Step 4) is simpler than entitlements.
+Entra has no built-in source for `entitlements`, and `entitlements` is not in its default attribute list. To send them, open **Provisioning** → **Mappings** → **Show advanced options** → **Edit attribute list**, add `entitlements`, then map it from a constant value or a directory extension attribute that holds the URN. For most setups, it is simpler to grant environment and resource group access through **roles** (Step 4) than through entitlements.
 
 #### Step 6. Provision
 

--- a/docs/articles/scim.md
+++ b/docs/articles/scim.md
@@ -342,6 +342,7 @@ Afterwards enable SCIM integration in the desired organization via the dashboard
 - Reference environments and resource groups by ID or slug, not display name.
 - Look for `ignoring all SCIM roles: no value matched the expected format` in the control plane API logs. The warning lists the values it rejected and the format it expected, which usually points straight at a malformed URN.
 - Entra ID only: if a role comes through as a friendly name like `Admin` instead of the URN, the app role's display name is still the friendly name. Entra sends the display name, not the value, so set the display name to the URN.
+- Okta only: if a user is in more than one Okta group and only the values from one group arrive, the app attributes still use the default **Use Group Priority** option. Select **Combine values across groups** on the `roles` and `entitlements` attributes (see [Users in Multiple Okta Groups](#users-in-multiple-okta-groups)).
 
 ### SCIM request failures
 
@@ -448,6 +449,27 @@ Mapping the attributes only tells Okta where to send them — you still set the 
 
 Okta sends the values to Testkube on the next sync, or right away when you assign the user to the app.
 
+#### Users in Multiple Okta Groups
+
+By default, Okta applies the **Use Group Priority** option to app attributes. When a user gets the app through more than one group, Okta sends the `roles` and `entitlements` values from the highest priority group only. The values from the other groups are not sent, so the user does not get that access in Testkube.
+
+If you model access with several groups, for example one group per environment or per resource group, switch both attributes to combine mode:
+
+1. Go to **Directory** → **Profile Editor** and select the Testkube SCIM application.
+2. Edit the `roles` attribute and select **Combine values across groups** as the group priority option. Save.
+3. Repeat for the `entitlements` attribute.
+
+Okta then sends the union of the values from all groups that assign the app to the user. When you remove a user from a group, Okta recomputes the combined values and pushes a profile update. Testkube then removes the access that is no longer listed.
+
+Note these constraints:
+
+- The option is available only for array attributes (the string array type from Step 1). It is not available for attributes with the **User personal** scope.
+- Okta combines the values that you set on the group **app assignments**. Okta does not combine attributes on the Okta group profile itself.
+- A direct (individual) app assignment overrides the values from group assignments. Assign the application through groups only.
+- Give each resource one role across all groups of a user. When two groups set a different role for the same environment or resource group, for example `read` and `admin`, Testkube applies the first value in the array, and the order is not guaranteed.
+
+Keep the default **Use Group Priority** option when every user gets the app from a single group.
+
 ### Microsoft Entra ID (Azure AD)
 
 This guide integrates Microsoft Entra ID with Testkube for **SCIM provisioning**. Entra sends the complex attribute format, so turn on complex format for the organization first (see [Roles and Entitlements Format](#roles-and-entitlements-format)).
@@ -477,17 +499,47 @@ Go to **Provisioning** → **Mappings** → **Provision Microsoft Entra ID Users
 
 #### Step 4. Send Roles
 
-Entra builds the `roles` value from a user's **app role assignment**, and it sends the app role's **display name**, not its value. So the display name has to be the Testkube role URN.
+Entra builds the `roles` value from a user's **app role assignments**, and it sends the app role's **display name**, not its value. So the display name has to be the Testkube role URN.
+
+First create the app roles:
 
 1. In **App registrations**, open your app (the non-gallery app you created also appears here), go to **App roles**, and create a role:
    - **Display name** → the Testkube URN, for example `urn:testkube:role:organization:*:admin`
    - **Value** → the same URN
    - **Allowed member types** → Users/Groups
-2. Back in the app's **Provisioning** → **Mappings**, click **Add New Mapping**:
+2. Repeat for every URN you want to assign.
+
+Then map the app roles to the SCIM `roles` attribute. Pick the mapping that matches your setup.
+
+**One role per user: `SingleAppRoleAssignment`**
+
+Use this mapping when every user holds exactly one app role.
+
+1. In the app's **Provisioning** → **Mappings**, click **Add New Mapping**:
    - **Mapping type** → Expression
    - **Expression** → `SingleAppRoleAssignment([appRoleAssignments])`
    - **Target attribute** → `roles[primary eq "True"].value`
-3. Go to **Users and groups**, add a user, and assign the app role you created.
+2. Go to **Users and groups**, add a user, and assign the app role you created.
+
+When a user holds more than one app role, this mapping sends only one of them, and Entra gives no guarantee which one. Use the next mapping instead.
+
+**Multiple roles per user: `AssertiveAppRoleAssignmentsComplex`**
+
+Use this mapping when users can hold several app roles at once, for example when each Entra group assigns its own app role and users belong to several groups.
+
+1. In **Provisioning** → **Mappings**, open **Show advanced options** → **Edit attribute list**, and add `roles` as a multi-valued attribute if it is not in the list.
+2. Click **Add New Mapping**:
+   - **Mapping type** → Expression
+   - **Expression** → `AssertiveAppRoleAssignmentsComplex([appRoleAssignments])`
+   - **Target attribute** → `roles`
+3. Remove the `SingleAppRoleAssignment` mapping if it exists. The two mappings must not target `roles` at the same time.
+4. Go to **Users and groups**, and assign users or groups to the app roles. Entra sends all roles of a user, from all assignments, as one array.
+
+Notes on the complex mappings:
+
+- `AssertiveAppRoleAssignmentsComplex` sends a PATCH replace operation, so a role you remove in Entra is also removed in Testkube. The similar `AppRoleAssignmentsComplex` expression only adds roles and never removes them. Do not use it, because Testkube then keeps roles that you already removed in Entra.
+- The complex expressions do not work with the provisioning scope **Sync all users and groups**. Set the scope to **Sync only assigned users and groups**.
+- Give each resource one role across all app roles of a user. When two app roles set a different role for the same environment or resource group, Testkube applies the first value in the array.
 
 #### Step 5. Send Entitlements (optional)
 


### PR DESCRIPTION
Customers who assign the Testkube SCIM app through several IdP groups lose the roles and entitlements from all groups except one. This PR documents the IdP settings that send the union of the values.

- Okta: a new section explains the default Use Group Priority behavior, the Combine values across groups option, its constraints, and when to use each option.
- Entra ID: the Send Roles step now covers two mappings. SingleAppRoleAssignment provisions one role per user. AssertiveAppRoleAssignmentsComplex provisions all app roles of a user as one array and removes roles on unassignment. The section also warns against AppRoleAssignmentsComplex, which adds roles but never removes them.
- Troubleshooting: a new bullet for the symptom where only the values from one Okta group arrive.
- The second commit aligns the prose of the whole guide with Simplified Technical English.