### PR TITLE
docs: correct AI model defaults and hosted proxy docs for gpt-5.2/gpt-5-mini

### DIFF
--- a/docs/articles/ai-configuration.mdx
+++ b/docs/articles/ai-configuration.mdx
@@ -31,7 +31,7 @@ to make additional models available for AI Chats. See [Configuring AI Models](/a
 
 ### Default LLM and Model
 
-The default LLM used by AI functionality is OpenAI's [GPT-5.2-Codex](https://openai.com/index/introducing-gpt-5-2-codex/).
+The default LLM used by AI functionality is OpenAI's GPT-5.2.
 
 For Cloud installations, the platform default model is managed by Testkube. You can add additional models
 via [Custom Models](/articles/ai-models) in the Dashboard.
@@ -60,10 +60,10 @@ testkube-ai-service:
       secretRef: "<secret-name>" # K8s secret storing the API key
       secretRefKey: "api-key" # Key within the secret
     agent:
-      - model: gpt-4o
+      - model: gpt-5.2
         default: true
     tasks:
-      model: gpt-4o-mini
+      model: gpt-5-mini
     embeddings:
       model: text-embedding-3-small
 
@@ -114,18 +114,18 @@ The `defaults` section provides shared values inherited by all models unless ove
 
 Each model entry (`agent`, `tasks`, `embeddings`) supports these fields in addition to inheriting from `defaults`:
 
-| Field          | Description                                                    |
-| -------------- | -------------------------------------------------------------- |
-| `model`        | Model identifier sent in the API request body (e.g., `gpt-4o`) |
-| `url`          | Custom endpoint URL (overrides `defaults.url`)                 |
-| `apiKey`       | API key for this model (overrides `defaults.apiKey`)           |
-| `secretRef`    | K8s secret name (overrides `defaults.secretRef`)               |
-| `secretRefKey` | Key within the secret (overrides `defaults.secretRefKey`)      |
-| `extraHeaders` | Extra HTTP headers (replaces `defaults.extraHeaders` if set)   |
-| `queryParams`  | Query parameters (replaces `defaults.queryParams` if set)      |
-| `temperature`  | Temperature setting — agent and tasks only                     |
-| `label`        | Human-readable name for the UI dropdown — agent only           |
-| `default`      | Mark which agent model is the default — agent only             |
+| Field          | Description                                                     |
+| -------------- | --------------------------------------------------------------- |
+| `model`        | Model identifier sent in the API request body (e.g., `gpt-5.2`) |
+| `url`          | Custom endpoint URL (overrides `defaults.url`)                  |
+| `apiKey`       | API key for this model (overrides `defaults.apiKey`)            |
+| `secretRef`    | K8s secret name (overrides `defaults.secretRef`)                |
+| `secretRefKey` | Key within the secret (overrides `defaults.secretRefKey`)       |
+| `extraHeaders` | Extra HTTP headers (replaces `defaults.extraHeaders` if set)    |
+| `queryParams`  | Query parameters (replaces `defaults.queryParams` if set)       |
+| `temperature`  | Temperature setting — agent and tasks only                      |
+| `label`        | Human-readable name for the UI dropdown — agent only            |
+| `default`      | Mark which agent model is the default — agent only              |
 
 :::info Override Semantics
 Per-model `extraHeaders` and `queryParams` **replace** the defaults entirely (not merged key-by-key). If you need both default and model-specific headers, repeat the shared ones in the per-model block.
@@ -141,10 +141,10 @@ inference:
     secretRef: "openai-secret"
     secretRefKey: "api-key"
   agent:
-    - model: gpt-4o
+    - model: gpt-5.2
       default: true
   tasks:
-    model: gpt-4o-mini
+    model: gpt-5-mini
   embeddings:
     model: text-embedding-3-small
 ```
@@ -161,12 +161,12 @@ inference:
     queryParams:
       api-version: "2024-02-01"
   agent:
-    - model: gpt-4o
+    - model: gpt-5.2
       default: true
-      url: "https://myresource.openai.azure.com/openai/deployments/gpt-4o"
+      url: "https://myresource.openai.azure.com/openai/deployments/gpt-5.2"
   tasks:
-    model: gpt-4o-mini
-    url: "https://myresource.openai.azure.com/openai/deployments/gpt-4o-mini"
+    model: gpt-5-mini
+    url: "https://myresource.openai.azure.com/openai/deployments/gpt-5-mini"
   embeddings:
     model: text-embedding-3-small
     url: "https://myresource.openai.azure.com/openai/deployments/text-embedding-3-small"
@@ -197,11 +197,11 @@ inference:
     url: "https://litellm.corp.internal/v1"
     apiKey: "proxy-master-key"
   agent:
-    - model: openai/gpt-4o
+    - model: openai/gpt-5.2
       default: true
     - model: anthropic/claude-sonnet-4-20250514
   tasks:
-    model: openai/gpt-4o-mini
+    model: openai/gpt-5-mini
   embeddings:
     model: openai/text-embedding-3-small
 ```
@@ -217,11 +217,11 @@ inference:
       extraHeaders:
         x-api-key: "sk-ant-..."
         anthropic-version: "2023-06-01"
-    - model: gpt-4o
+    - model: gpt-5.2
       url: "https://api.openai.com/v1"
       apiKey: "sk-proj-..."
   tasks:
-    model: gpt-4o-mini
+    model: gpt-5-mini
     url: "https://api.openai.com/v1"
     apiKey: "sk-proj-..."
   embeddings:
@@ -239,10 +239,10 @@ inference:
     secretRef: "ai-service-llm-keys"
     secretRefKey: "openai-api-key"
   agent:
-    - model: gpt-4o
+    - model: gpt-5.2
       default: true
   tasks:
-    model: gpt-4o-mini
+    model: gpt-5-mini
   embeddings:
     model: text-embedding-3-small
     secretRef: "ai-service-embeddings-key"
@@ -258,9 +258,20 @@ testkube-ai-service:
     defaults:
       url: "https://llm.testkube.io"
     agent:
-      - model: gpt-4o
+      - model: gpt-5.2
         default: true
+    tasks:
+      model: gpt-5-mini
 ```
+
+The hosted proxy serves a fixed set of models chosen by Testkube — you cannot add to it:
+
+- **Chat**: `gpt-5.2` and `gpt-5-mini`
+- **Embeddings**: `text-embedding-ada-002`
+
+Any other model name returns an invalid-model error from the proxy. This includes `gpt-4o` and
+`gpt-4o-mini`, which the hosted proxy no longer serves — move any configuration still naming them to
+`gpt-5.2` / `gpt-5-mini`.
 
 :::warning
 The hosted proxy is intended **only for trials, demos, and onboarding**. It has usage limits and is not recommended for production workloads.
@@ -331,7 +342,7 @@ testkube-ai-service:
 testkube-ai-service:
   enabled: true
   models:
-    - name: gpt-5.2-codex
+    - name: gpt-5.2
       type: primary
       temperature: 0
     - name: gpt-5-mini

--- a/docs/articles/ai-enabling.mdx
+++ b/docs/articles/ai-enabling.mdx
@@ -10,7 +10,7 @@ For users of the Testkube Cloud Control Plane, AI features are enabled as follow
   2. Navigate to **Organization Settings** → **Product Features** tab and toggle **AI Assistant** on.
 
 :::info
-The default LLM used by AI functionality in Testkube Cloud is OpenAI's [GPT-5.2-Codex](https://openai.com/index/introducing-gpt-5-2-codex/).
+The default LLM used by AI functionality in Testkube Cloud is OpenAI's GPT-5.2.
 
 You can add your own models (OpenAI, Azure OpenAI, or any OpenAI-compatible service) to make
 additional models available — see [Configuring AI Models](/articles/ai-models).
@@ -44,10 +44,10 @@ testkube-ai-service:
       secretRef: my-openai-secret
       secretRefKey: api-key
     agent:
-      - model: gpt-4o
+      - model: gpt-5.2
         default: true
     tasks:
-      model: gpt-4o-mini
+      model: gpt-5-mini
     embeddings:
       model: text-embedding-3-small
 
@@ -75,12 +75,12 @@ testkube-ai-service:
       queryParams:
         api-version: "2024-02-01"
     agent:
-      - model: gpt-4o
+      - model: gpt-5.2
         default: true
-        url: "https://my-company.openai.azure.com/openai/deployments/gpt-4o"
+        url: "https://my-company.openai.azure.com/openai/deployments/gpt-5.2"
     tasks:
-      model: gpt-4o-mini
-      url: "https://my-company.openai.azure.com/openai/deployments/gpt-4o-mini"
+      model: gpt-5-mini
+      url: "https://my-company.openai.azure.com/openai/deployments/gpt-5-mini"
     # Omit embeddings if your provider doesn't support /v1/embeddings
 ```
 

--- a/docs/articles/ai-models.md
+++ b/docs/articles/ai-models.md
@@ -52,7 +52,7 @@ Select the **Add Model** button to open the model configuration modal with the f
 
 After adding a model, configure the model names that you want to make available:
 
-- For **OpenAI** providers, use model names like `gpt-4o`, `o3-mini`, etc.
+- For **OpenAI** providers, use model names like `gpt-5.2`, `gpt-5-mini`, etc.
 - For **OpenAI Compatible** providers, use the model identifiers expected by your service (e.g., `anthropic/claude-opus-4.6`, `google/gemini-3-flash`). You can also set a custom endpoint URL per model — useful for Azure OpenAI where each model has its own deployment URL.
 
 ### Extra Headers and Query Parameters


### PR DESCRIPTION
## What

Updates the AI configuration docs (`ai-configuration.mdx`, `ai-enabling.mdx`, `ai-models.md`) to match what `llm.testkube.io` has actually served since August: `gpt-5.2` and `gpt-5-mini`, not `gpt-4o`/`gpt-4o-mini`. Every illustrative example across the three articles is updated, and the hosted trial proxy section now states plainly which models it serves — `gpt-5.2` and `gpt-5-mini` for chat, `text-embedding-ada-002` for embeddings — and that any other name, including the retired `gpt-4o` pair, is rejected.

Also corrects three places that claimed the platform default was "GPT-5.2-Codex", which was never actually configured anywhere in the stack.

## Why

`kubeshop/testkube-deployment` PR #743 (2026-08-06) swapped `gpt-4o`/`gpt-4o-mini` for `gpt-5.2`/`gpt-5-mini` on the hosted proxy but shipped no docs update, so the docs described a config that no longer works. This is the docs half of that change.

Verified live against `llm.testkube.io`: the proxy serves exactly `gpt-5.2`, `gpt-5-mini` and `text-embedding-ada-002`, all from git config with nothing added through the admin UI.

Restoring the old models was considered and deliberately declined — the hosted proxy had no customer traffic before the swap — so the docs state the removal as permanent rather than as a deprecation with a grace period.

The "GPT-5.2-Codex" correction is unrelated and rides along because a reviewer would otherwise notice it in the diff and wonder. That model is responses-API only while the stack uses chat completions, so the documented config could not have worked even with a customer's own OpenAI key.

## Note for the reviewer

The OpenAI announcement link on the "GPT-5.2-Codex" sites was dropped rather than swapped for a GPT-5.2 equivalent, because `openai.com` returns 403 to scripted requests and no replacement URL could be verified. If you can confirm a working URL in a browser, restoring the link is a one-line addition.

Closes TKC-6305 together with the already-shipped deployment change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
