### PR TITLE
Document targeted execution scheduler policy

### DIFF
--- a/docs/articles/scheduling-tests.mdx
+++ b/docs/articles/scheduling-tests.mdx
@@ -27,6 +27,32 @@ spec:
 ...
 ```
 
+### Skip schedules without a matching Runner Agent
+
+When the same Workflow is synchronized to multiple environments, add `schedulerPolicy: OnlyWhenMatches` to each targeted
+schedule. The Control Plane creates an execution only in environments containing a matching Runner Agent:
+
+```yaml
+spec:
+  events:
+    - cronjob:
+        cron: "0 3 * * *"
+        target:
+          schedulerPolicy: OnlyWhenMatches
+          match:
+            environment:
+              - production
+```
+
+Offline Runner Agents count as matches so the execution can wait for them to reconnect. Deleted or nonexistent runners do
+not count. Omitting `schedulerPolicy` keeps the existing behavior and creates a queued execution even when no runner matches.
+
+:::warning
+`OnlyWhenMatches` requires PostgreSQL and must be enabled only after every Control Plane replica and the Agent CRDs have been
+upgraded to a version that supports it. Older components ignore, prune, or reject the field; rolling back temporarily restores
+the previous queueing behavior.
+:::
+
 :::tip
 Testkube uses the same scheduling format as Kubernetes Cron jobs. For details on the cron expression syntax,
 refer to the [Wikipedia Cron format](https://en.wikipedia.org/wiki/Cron) for details.

--- a/docs/articles/test-workflows-running.mdx
+++ b/docs/articles/test-workflows-running.mdx
@@ -251,10 +251,16 @@ Each of these definitions supports a corresponding `target` property:
 
 ```yaml
 target:
+  schedulerPolicy: OnlyWhenMatches # optional
   match: [<label>: <values>]
   not: [<label>: <values>]
   replicate: [<labels>]
 ```
+
+`schedulerPolicy: OnlyWhenMatches` is available anywhere this shared `target` structure is accepted, including Workflows,
+WorkflowTemplates, Workflow CronJobs, Triggers, execution CRDs, and API execution requests. It prevents creation of an
+execution when no existing, non-deleted Runner Agent in that environment matches the normalized target. Without the field,
+targeted executions retain their existing queueing behavior.
 
 The following targets a specific Runner Agent by name:
 


### PR DESCRIPTION
## Summary

- document `target.schedulerPolicy: OnlyWhenMatches`
- explain matching, offline/deleted runner behavior, and PostgreSQL support
- document upgrade ordering, mixed-version behavior, and rollback limitations
- include the shared-workflow, multi-environment targeting example

## Linear

- [TKC-6090](https://linear.app/kubeshop/issue/TKC-6090)
- [TKC-6091](https://linear.app/kubeshop/issue/TKC-6091)

## Validation

- Prettier check passed
- Docusaurus webpack compilation passed; the existing theme/SSG incompatibility still prevents the complete docs build
